### PR TITLE
fix(styles): replace undefined $foreground with $pfx-fg for panel tex…

### DIFF
--- a/passfx/styles/passfx.tcss
+++ b/passfx/styles/passfx.tcss
@@ -26,7 +26,7 @@ $pfx-muted: #94a3b8;
 
 Screen {
     background: #0f172a;
-    color: $foreground;
+    color: $pfx-fg;
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
@@ -312,7 +312,7 @@ Label {
 
 Static {
     padding: 0;
-    color: $foreground;
+    color: $pfx-fg;
 }
 
 .info {


### PR DESCRIPTION
…t visibility

The CSS file referenced $foreground which was never defined, causing text in panels and Static widgets to be invisible against the dark background. Replaced with $pfx-fg (#f8fafc) which is properly defined in the color palette.