### PR TITLE
security(runtime): implement Day 3 runtime safety fixes

### DIFF
--- a/passfx/app.py
+++ b/passfx/app.py
@@ -17,6 +17,7 @@ class PassFXApp(App):
     TITLE = "◀ PASSFX ▶ Your passwords. Offline. Encrypted."
 
     BINDINGS = [
+        Binding("ctrl+c", "quit", "Quit", priority=True),
         Binding("q", "quit", "Quit", show=True),
         Binding("escape", "back", "Back", show=True),
     ]

--- a/passfx/cli.py
+++ b/passfx/cli.py
@@ -1,15 +1,24 @@
-"""Main CLI entry point for PassFX."""
+"""Main CLI entry point for PassFX.
+
+Entry point with signal handling for graceful shutdown and cleanup.
+"""
 
 from __future__ import annotations
 
+import signal
 import sys
+from types import FrameType
 
 import setproctitle
 
 from passfx.app import PassFXApp
+from passfx.utils.clipboard import emergency_cleanup
 
 # Terminal title - shown in terminal tab/window
 TERMINAL_TITLE = "◀ PASSFX ▶ Your passwords. Offline. Encrypted."
+
+# Global app reference for signal handlers
+_app: PassFXApp | None = None  # pylint: disable=invalid-name
 
 
 def set_terminal_title(title: str) -> None:
@@ -18,18 +27,60 @@ def set_terminal_title(title: str) -> None:
     sys.stdout.flush()
 
 
+def _signal_handler(signum: int, _frame: FrameType | None) -> None:
+    """Handle termination signals with cleanup.
+
+    Ensures vault is locked and clipboard is cleared on SIGINT/SIGTERM.
+    """
+    # Clear clipboard first (most critical)
+    emergency_cleanup()
+
+    # Lock vault if app exists and is unlocked
+    if _app is not None:
+        try:
+            if _app.vault and _app._unlocked:
+                _app.vault.lock()
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass  # Fail silently during shutdown
+
+    # Exit with appropriate code
+    # SIGINT (Ctrl-C) = 130, SIGTERM = 143
+    sys.exit(128 + signum)
+
+
+def _setup_signal_handlers() -> None:
+    """Register signal handlers for graceful shutdown."""
+    signal.signal(signal.SIGINT, _signal_handler)
+    signal.signal(signal.SIGTERM, _signal_handler)
+
+
 def main() -> int:
     """Main entry point for PassFX.
 
     Returns:
         Exit code (0 for success).
     """
+    global _app  # pylint: disable=global-statement
+
     # Set process title (removes "Python" from terminal tab)
     setproctitle.setproctitle("PassFX")
     set_terminal_title(TERMINAL_TITLE)
 
-    app = PassFXApp()
-    app.run()
+    # Register signal handlers before app starts
+    _setup_signal_handlers()
+
+    _app = PassFXApp()
+    try:
+        _app.run()
+    finally:
+        # Ensure cleanup on any exit path
+        emergency_cleanup()
+        if _app.vault and _app._unlocked:
+            try:
+                _app.vault.lock()
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+
     return 0
 
 

--- a/passfx/screens/cards.py
+++ b/passfx/screens/cards.py
@@ -667,9 +667,9 @@ class ViewCardModal(ModalScreen[None]):
             self._copy_number()
 
     def _copy_number(self) -> None:
-        """Copy card number to clipboard."""
-        if copy_to_clipboard(self.card.card_number, auto_clear=True, clear_after=30):
-            self.notify("Card number copied! Clears in 30s", title="Copied")
+        """Copy card number to clipboard with auto-clear for security."""
+        if copy_to_clipboard(self.card.card_number, auto_clear=True):
+            self.notify("Card number copied! Clears in 15s", title="Copied")
         else:
             self.notify("Failed to copy to clipboard", severity="error")
 
@@ -954,14 +954,14 @@ class CardsScreen(Screen):
         self.app.push_screen(AddCardModal(), handle_result)
 
     def action_copy(self) -> None:
-        """Copy card number to clipboard."""
+        """Copy card number to clipboard with auto-clear for security."""
         card = self._get_selected_card()
         if not card:
             self.notify("No card selected", severity="warning")
             return
 
-        if copy_to_clipboard(card.card_number, auto_clear=True, clear_after=30):
-            self.notify("Card number copied! Clears in 30s", title=card.label)
+        if copy_to_clipboard(card.card_number, auto_clear=True):
+            self.notify("Card number copied! Clears in 15s", title=card.label)
         else:
             self.notify("Failed to copy to clipboard", severity="error")
 

--- a/passfx/screens/envs.py
+++ b/passfx/screens/envs.py
@@ -264,9 +264,9 @@ class ViewEnvModal(ModalScreen[None]):
             self._copy_content()
 
     def _copy_content(self) -> None:
-        """Copy content to clipboard."""
-        if copy_to_clipboard(self.env.content, auto_clear=False):
-            self.notify("Config copied to clipboard", title="Copied")
+        """Copy content to clipboard with auto-clear for security."""
+        if copy_to_clipboard(self.env.content, auto_clear=True):
+            self.notify("Config copied! Clears in 15s", title="Copied")
         else:
             self.notify("Failed to copy to clipboard", severity="error")
 
@@ -832,14 +832,14 @@ class EnvsScreen(Screen):
         self.app.push_screen(AddEnvModal(), handle_result)
 
     def action_copy(self) -> None:
-        """Copy content to clipboard."""
+        """Copy content to clipboard with auto-clear for security."""
         env = self._get_selected_env()
         if not env:
             self.notify("No config selected", severity="warning")
             return
 
-        if copy_to_clipboard(env.content, auto_clear=False):
-            self.notify("Config copied to clipboard", title=env.title)
+        if copy_to_clipboard(env.content, auto_clear=True):
+            self.notify("Config copied! Clears in 15s", title=env.title)
         else:
             self.notify("Failed to copy to clipboard", severity="error")
 

--- a/passfx/screens/notes.py
+++ b/passfx/screens/notes.py
@@ -242,9 +242,9 @@ class ViewNoteModal(ModalScreen[None]):
             self._copy_content()
 
     def _copy_content(self) -> None:
-        """Copy content to clipboard."""
-        if copy_to_clipboard(self.note.content, auto_clear=False):
-            self.notify("Note copied to clipboard", title="Copied")
+        """Copy content to clipboard with auto-clear for security."""
+        if copy_to_clipboard(self.note.content, auto_clear=True):
+            self.notify("Note copied! Clears in 15s", title="Copied")
         else:
             self.notify("Failed to copy to clipboard", severity="error")
 
@@ -652,14 +652,14 @@ class NotesScreen(Screen):
         self.app.push_screen(AddNoteModal(), handle_result)
 
     def action_copy(self) -> None:
-        """Copy content to clipboard."""
+        """Copy content to clipboard with auto-clear for security."""
         entry = self._get_selected_entry()
         if not entry:
             self.notify("No note selected", severity="warning")
             return
 
-        if copy_to_clipboard(entry.content, auto_clear=False):
-            self.notify("Note copied to clipboard", title=entry.title)
+        if copy_to_clipboard(entry.content, auto_clear=True):
+            self.notify("Note copied! Clears in 15s", title=entry.title)
         else:
             self.notify("Failed to copy to clipboard", severity="error")
 

--- a/passfx/screens/passwords.py
+++ b/passfx/screens/passwords.py
@@ -528,9 +528,9 @@ class ViewPasswordModal(ModalScreen[None]):
             self._copy_password()
 
     def _copy_password(self) -> None:
-        """Copy password to clipboard."""
-        if copy_to_clipboard(self.credential.password, auto_clear=True, clear_after=30):
-            self.notify("Password copied! Clears in 30s", title="Copied")
+        """Copy password to clipboard with auto-clear for security."""
+        if copy_to_clipboard(self.credential.password, auto_clear=True):
+            self.notify("Password copied! Clears in 15s", title="Copied")
         else:
             self.notify("Failed to copy to clipboard", severity="error")
 
@@ -779,14 +779,14 @@ class PasswordsScreen(Screen):
         self.app.push_screen(AddPasswordModal(), handle_result)
 
     def action_copy(self) -> None:
-        """Copy password to clipboard."""
+        """Copy password to clipboard with auto-clear for security."""
         cred = self._get_selected_credential()
         if not cred:
             self.notify("No credential selected", severity="warning")
             return
 
-        if copy_to_clipboard(cred.password, auto_clear=True, clear_after=30):
-            self.notify("Password copied! Clears in 30s", title=cred.label)
+        if copy_to_clipboard(cred.password, auto_clear=True):
+            self.notify("Password copied! Clears in 15s", title=cred.label)
         else:
             self.notify("Failed to copy to clipboard", severity="error")
 


### PR DESCRIPTION
- Add SIGINT/SIGTERM signal handlers for graceful shutdown
- Add Ctrl-C keybinding for in-app termination
- Implement emergency_cleanup() with atexit registration
- Reduce clipboard timeout from 30s to 15s
- Enable auto-clear for notes and env vars clipboard operations
- Ensure vault lock and clipboard clear on all exit paths

Fixes runtime exposure windows and ensures secrets are cleaned up during abnormal termination scenarios.

