### PR TITLE
security(vault): implement Day 4 filesystem and concurrency fixes

### DIFF
--- a/passfx/screens/settings.py
+++ b/passfx/screens/settings.py
@@ -14,7 +14,12 @@ from textual.screen import ModalScreen, Screen
 from textual.widgets import Button, Footer, Header, Input, Label, OptionList, Static
 from textual.widgets.option_list import Option
 
-from passfx.utils.io import ImportExportError, export_vault, import_vault
+from passfx.utils.io import (
+    ImportExportError,
+    PathValidationError,
+    export_vault,
+    import_vault,
+)
 
 if TYPE_CHECKING:
     from passfx.app import PassFXApp
@@ -85,6 +90,8 @@ class ExportModal(ModalScreen[None]):
             count = export_vault(data, path, fmt=fmt, include_sensitive=True)
             status.update(f"[success]Exported {count} entries to {path}[/success]")
             self.notify(f"Exported {count} entries", title="Success")
+        except PathValidationError as e:
+            status.update(f"[error]Invalid path: {e}[/error]")
         except ImportExportError as e:
             status.update(f"[error]{e}[/error]")
 
@@ -131,9 +138,6 @@ class ImportModal(ModalScreen[None]):
             return
 
         path = Path(path_str).expanduser()
-        if not path.exists():
-            status.update(f"[error]File not found: {path}[/error]")
-            return
 
         try:
             data, _ = import_vault(path)
@@ -141,6 +145,8 @@ class ImportModal(ModalScreen[None]):
             total = sum(imported.values())
             status.update(f"[success]Imported {total} entries[/success]")
             self.notify(f"Imported {total} entries", title="Success")
+        except PathValidationError as e:
+            status.update(f"[error]Invalid path: {e}[/error]")
         except ImportExportError as e:
             status.update(f"[error]{e}[/error]")
 


### PR DESCRIPTION
## Summary

- Add cross-platform file locking (fcntl/msvcrt) for exclusive vault access
- Implement salt file integrity checking with SHA-256 hash verification
- Add atomic salt file creation with secure permissions (0600)
- Add import/export path validation (home directory constraint, symlink rejection)
- New exceptions: `VaultLockError`, `SaltIntegrityError`, `PathValidationError`

## Changes

### FIX 1: File Locking for Vault Access (Critical)
- Cross-platform exclusive locking: `fcntl.flock()` on Unix, `msvcrt.locking()` on Windows
- Lock acquired during `create()`, `unlock()`, and `_save()` operations
- 5-second timeout prevents indefinite hangs
- Context manager ensures lock release on exceptions

### FIX 2: Salt File Integrity & Hardening
- Atomic salt file creation via temp file + fsync + rename pattern
- Salt hash cached at unlock time for integrity verification
- Detects deleted/modified/replaced salt files before save
- Symlink attack detection on salt file

### FIX 3: Import/Export Path Validation
- Paths constrained to user's home directory
- Symlinks rejected on both file and parent directory
- Paths normalized and resolved before use

## Test plan

- [ ] Verify two PassFX instances cannot modify vault simultaneously
- [ ] Confirm vault operations fail gracefully when lock held by another process
- [ ] Test salt file deletion detection (should fail to save)
- [ ] Test salt file modification detection (should fail to save)
- [ ] Verify symlink attacks on salt file are blocked
- [ ] Test export to path outside home directory (should fail)
- [ ] Test import from symlinked file (should fail)
- [ ] Test import/export with symlinked parent directory (should fail)