### PR TITLE
chore(quality): add linter and security tool annotations

### DIFF
--- a/passfx/app.py
+++ b/passfx/app.py
@@ -40,14 +40,14 @@ def _graceful_shutdown(_signum: int, _frame: Any) -> None:
         try:
             if _app_instance.vault and _app_instance._unlocked:
                 _app_instance.vault.lock()
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass  # Fail silently during shutdown
+        except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+            pass  # Intentional: shutdown must not raise
 
     # Clear clipboard - critical for security
     try:
         emergency_cleanup()
-    except Exception:  # pylint: disable=broad-exception-caught
-        pass  # Fail silently during shutdown
+    except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+        pass  # Intentional: shutdown must not raise
 
     # Exit cleanly
     sys.exit(0)
@@ -79,14 +79,14 @@ def _cleanup_on_exit() -> None:
         try:
             if _app_instance.vault and _app_instance._unlocked:
                 _app_instance.vault.lock()
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass
+        except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+            pass  # Intentional: atexit must not raise
 
     # Clear clipboard
     try:
         clear_clipboard()
-    except Exception:  # pylint: disable=broad-exception-caught
-        pass
+    except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+        pass  # Intentional: atexit must not raise
 
 
 class PassFXApp(App):

--- a/passfx/cli.py
+++ b/passfx/cli.py
@@ -40,8 +40,8 @@ def _signal_handler(signum: int, _frame: FrameType | None) -> None:
         try:
             if _app.vault and _app._unlocked:
                 _app.vault.lock()
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass  # Fail silently during shutdown
+        except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+            pass  # Intentional: signal handler must not raise
 
     # Exit with appropriate code
     # SIGINT (Ctrl-C) = 130, SIGTERM = 143
@@ -78,8 +78,8 @@ def main() -> int:
         if _app.vault and _app._unlocked:
             try:
                 _app.vault.lock()
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
+            except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+                pass  # Intentional: cleanup must not raise
 
     return 0
 

--- a/passfx/screens/cards.py
+++ b/passfx/screens/cards.py
@@ -917,15 +917,15 @@ class CardsScreen(Screen):
         if old_key and old_key in card_map:
             try:
                 table.update_cell(old_key, indicator_col, " ")
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass  # Row may not exist
+            except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+                pass  # Row may not exist during rapid navigation
 
         # Set new selection indicator
         if new_key and new_key in card_map:
             try:
                 table.update_cell(new_key, indicator_col, "[bold #10b981]▍[/]")
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass  # Row may not exist
+            except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+                pass  # Row may not exist during rapid navigation
 
     def _get_selected_card(self) -> CreditCard | None:
         """Get the currently selected card."""

--- a/passfx/screens/envs.py
+++ b/passfx/screens/envs.py
@@ -797,14 +797,14 @@ class EnvsScreen(Screen):
         if old_key and old_key in env_map:
             try:
                 table.update_cell(old_key, indicator_col, " ")
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
+            except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+                pass  # Row may not exist during rapid navigation
 
         if new_key and new_key in env_map:
             try:
                 table.update_cell(new_key, indicator_col, "[bold #6366f1]▍[/]")
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
+            except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+                pass  # Row may not exist during rapid navigation
 
     def _get_selected_env(self) -> EnvEntry | None:
         """Get the currently selected env entry."""

--- a/passfx/screens/login.py
+++ b/passfx/screens/login.py
@@ -70,7 +70,7 @@ class LoginScreen(Screen):
             with Vertical(id="login-content"):
                 yield Static(LOGO, id="logo")
                 yield Static(
-                    f'[italic #8b5cf6]"{random.choice(TAGLINES)}"[/]',
+                    f'[italic #8b5cf6]"{random.choice(TAGLINES)}"[/]',  # nosec B311 - cosmetic UI only
                     id="tagline",
                 )
 

--- a/passfx/screens/notes.py
+++ b/passfx/screens/notes.py
@@ -617,14 +617,14 @@ class NotesScreen(Screen):
         if old_key and old_key in entry_map:
             try:
                 table.update_cell(old_key, indicator_col, " ")
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
+            except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+                pass  # Row may not exist during rapid navigation
 
         if new_key and new_key in entry_map:
             try:
                 table.update_cell(new_key, indicator_col, "[bold #f59e0b]▍[/]")
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
+            except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+                pass  # Row may not exist during rapid navigation
 
     def _get_selected_entry(self) -> NoteEntry | None:
         """Get the currently selected note entry."""

--- a/passfx/screens/passwords.py
+++ b/passfx/screens/passwords.py
@@ -742,15 +742,15 @@ class PasswordsScreen(Screen):
         if old_key and old_key in cred_map:
             try:
                 table.update_cell(old_key, indicator_col, " ")
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass  # Row may not exist
+            except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+                pass  # Row may not exist during rapid navigation
 
         # Set new selection indicator
         if new_key and new_key in cred_map:
             try:
                 table.update_cell(new_key, indicator_col, "[bold #00d4ff]▍[/]")
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass  # Row may not exist
+            except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+                pass  # Row may not exist during rapid navigation
 
     def _get_selected_credential(self) -> EmailCredential | None:
         """Get the currently selected credential."""

--- a/passfx/screens/phones.py
+++ b/passfx/screens/phones.py
@@ -773,15 +773,15 @@ class PhonesScreen(Screen):
         if old_key and old_key in cred_map:
             try:
                 table.update_cell(old_key, indicator_col, " ")
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass  # Row may not exist
+            except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+                pass  # Row may not exist during rapid navigation
 
         # Set new selection indicator
         if new_key and new_key in cred_map:
             try:
                 table.update_cell(new_key, indicator_col, "[bold #8b5cf6]▍[/]")
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass  # Row may not exist
+            except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+                pass  # Row may not exist during rapid navigation
 
     def _get_selected_credential(self) -> PhoneCredential | None:
         """Get the currently selected credential."""

--- a/passfx/screens/recovery.py
+++ b/passfx/screens/recovery.py
@@ -752,14 +752,14 @@ class RecoveryScreen(Screen):
         if old_key and old_key in entry_map:
             try:
                 table.update_cell(old_key, indicator_col, " ")
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
+            except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+                pass  # Row may not exist during rapid navigation
 
         if new_key and new_key in entry_map:
             try:
                 table.update_cell(new_key, indicator_col, "[bold #f43f5e]▍[/]")
-            except Exception:  # pylint: disable=broad-exception-caught
-                pass
+            except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+                pass  # Row may not exist during rapid navigation
 
     def _get_selected_entry(self) -> RecoveryEntry | None:
         """Get the currently selected recovery entry."""

--- a/passfx/ui/logo.py
+++ b/passfx/ui/logo.py
@@ -53,7 +53,7 @@ def get_logo() -> str:
 
 def get_random_tagline() -> str:
     """Return a random nerdy tagline."""
-    return random.choice(TAGLINES)
+    return random.choice(TAGLINES)  # nosec B311 - cosmetic UI only
 
 
 def _apply_gradient(text: str, colors: list[str]) -> Text:

--- a/passfx/utils/clipboard.py
+++ b/passfx/utils/clipboard.py
@@ -43,7 +43,7 @@ def copy_to_clipboard(
     global _active_timer  # pylint: disable=global-statement
 
     try:
-        import pyperclip
+        import pyperclip  # type: ignore[import-untyped]
 
         pyperclip.copy(text)
 
@@ -130,13 +130,13 @@ def _fallback_copy(text: str) -> bool:
     Returns:
         True if successful, False otherwise.
     """
-    import subprocess
+    import subprocess  # nosec B404 - Required for clipboard fallback
     import sys
 
     try:
         if sys.platform == "darwin":
-            # macOS
-            with subprocess.Popen(
+            # macOS - pbcopy is a hardcoded system utility, not user input
+            with subprocess.Popen(  # nosec B603 B607
                 ["pbcopy"],
                 stdin=subprocess.PIPE,
                 close_fds=True,
@@ -147,7 +147,8 @@ def _fallback_copy(text: str) -> bool:
         if sys.platform.startswith("linux"):
             # Linux with xclip
             try:
-                with subprocess.Popen(
+                # xclip is a hardcoded system utility, not user input
+                with subprocess.Popen(  # nosec B603 B607
                     ["xclip", "-selection", "clipboard"],
                     stdin=subprocess.PIPE,
                     close_fds=True,
@@ -155,8 +156,8 @@ def _fallback_copy(text: str) -> bool:
                     process.communicate(text.encode("utf-8"))
                     return process.returncode == 0
             except FileNotFoundError:
-                # Try xsel
-                with subprocess.Popen(
+                # xsel is a hardcoded system utility, not user input
+                with subprocess.Popen(  # nosec B603 B607
                     ["xsel", "--clipboard", "--input"],
                     stdin=subprocess.PIPE,
                     close_fds=True,
@@ -184,8 +185,8 @@ def _fallback_copy(text: str) -> bool:
             user32.CloseClipboard()
             return True
 
-    except Exception:  # pylint: disable=broad-exception-caught
-        pass
+    except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+        pass  # Fallback must fail silently
 
     return False
 
@@ -267,8 +268,8 @@ def emergency_cleanup() -> None:
     # Clear clipboard - fail silently on errors
     try:
         clear_clipboard()
-    except Exception:  # pylint: disable=broad-exception-caught
-        pass
+    except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+        pass  # Emergency cleanup must not raise
 
 
 def reset_cleanup_flag() -> None:

--- a/passfx/utils/strength.py
+++ b/passfx/utils/strength.py
@@ -60,7 +60,8 @@ def check_strength(password: str) -> StrengthResult:
         return _simple_strength_check(password)
 
     try:
-        from zxcvbn import zxcvbn  # pylint: disable=import-outside-toplevel
+        # pylint: disable-next=import-outside-toplevel
+        from zxcvbn import zxcvbn  # type: ignore[import-untyped]
 
         result = zxcvbn(password)
 


### PR DESCRIPTION
## Summary

- Add type ignore comments for third-party libraries without type stubs (pyperclip, zxcvbn)
- Add `# nosec` annotations for intentional security tool suppressions (B110, B311, B404, B603, B607)
- Add pylint disable comments for documented broad-exception-caught patterns
- Fix import-outside-toplevel with `disable-next` directive

## Changes

| File | Changes |
|------|---------|
| `app.py`, `cli.py` | Shutdown/cleanup exception handlers |
| `clipboard.py` | Subprocess calls, type ignores, emergency cleanup |
| `strength.py` | Lazy import annotation, type ignore |
| `login.py`, `logo.py` | Cosmetic random.choice suppression |
| Screen files (6) | Row indicator update handlers |

## Test plan

- [x] `ruff check passfx/` - All checks passed
- [x] `mypy passfx/` - Success: no issues found in 32 source files
- [x] `bandit -r passfx/` - No issues (29 documented suppressions)
- [x] `pylint passfx/` - 10.00/10
- [x] All pre-commit hooks pass