### PR TITLE
security(auth): implement Day 7 blocking issue fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,13 +134,13 @@ Before pushing to GitHub, and **before providing a summary**:
 
 ### Cryptographic Standards
 
-| Requirement    | Specification          |
-| -------------- | ---------------------- |
-| Encryption     | AES-256-CBC via Fernet |
-| Key Derivation | PBKDF2-HMAC-SHA256     |
-| KDF Iterations | 480,000 minimum        |
-| Salt Length    | 32 bytes               |
-| RNG            | `secrets` module only  |
+| Requirement    | Specification                                      |
+| -------------- | -------------------------------------------------- |
+| Encryption     | Fernet (AES-128-CBC + HMAC-SHA256)                 |
+| Key Derivation | PBKDF2-HMAC-SHA256                                 |
+| KDF Iterations | 480,000 minimum                                    |
+| Salt Length    | 32 bytes                                           |
+| RNG            | `secrets` module only                              |
 
 ### File Permissions
 
@@ -379,7 +379,7 @@ vault_path = os.path.join(os.path.expanduser("~"), ".passfx", "vault.enc")
 
 ## Project Overview
 
-**PassFX** is a production-grade terminal-based password manager built with Python and Textual. AES-256 encrypted storage with a cyberpunk-themed TUI. Security, data integrity, and user privacy are paramount.
+**PassFX** is a production-grade terminal-based password manager built with Python and Textual. Fernet authenticated encryption (AES-128-CBC + HMAC-SHA256) with a cyberpunk-themed TUI. Security, data integrity, and user privacy are paramount.
 
 ### Tech Stack
 
@@ -387,7 +387,7 @@ vault_path = os.path.join(os.path.expanduser("~"), ".passfx", "vault.enc")
 | -------------- | ----------------------------- |
 | Framework      | Textual (TUI)                 |
 | Language       | Python 3.11+ (strict typing)  |
-| Encryption     | cryptography (Fernet/AES-256) |
+| Encryption     | cryptography (Fernet/AES-128) |
 | Key Derivation | PBKDF2 (480k iterations)      |
 | Styling        | Textual CSS (.tcss)           |
 | Clipboard      | pyperclip                     |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We take a paranoid, "local-first" approach to security. For a deep dive into our
 - **Offline Only:** No servers. No syncing. No "cloud backup." Because there is no cloud, only other people's computers.
 - **Zero Knowledge:** We cannot see your data. If you lose your master password, your data is mathematically irretrievable.
 - **Standard Primitives:** We do not roll our own crypto (rule #1 of crypto club).
-  - **Encryption:** AES-256-CBC via Fernet (with HMAC-SHA256 for integrity).
+  - **Encryption:** Fernet authenticated encryption (AES-128-CBC + HMAC-SHA256).
   - **Key Derivation:** PBKDF2-HMAC-SHA256 (480,000 iterations, exceeding OWASP 2023 recommendations).
   - **Randomness:** All secrets are generated using Python's `secrets` module (CSPRNG), never `random`.
 - **Memory Hygiene:** We employ best-effort memory wiping for sensitive keys and implement strict auto-lock timeouts.
@@ -143,7 +143,7 @@ A: Browsers are huge attack surfaces that connect to the internet. PassFX is a s
 A: On your hard drive. Specifically `~/.passfx/`. It works on my machine, and it stays on yours.
 
 **Q: I forgot my Master Password. Can you reset it?**
-A: No. We hash it more times than you've pushed to `main` on a Friday. The encryption is standard AES-256. Unless you have a few million years and a supercomputer, that data is gone.
+A: No. We hash it more times than you've pushed to `main` on a Friday. The encryption uses industry-standard Fernet (AES-128-CBC with HMAC-SHA256), which is NIST-approved and computationally secure. Unless you have a few million years and a supercomputer, that data is gone.
 
 **Q: Why "PassFX"?**
 A: Because "PasswordManagerForTerminalWrittenInPythonUsingTextual" was rejected by PyPI for being too verbose.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,7 +14,7 @@ Think of PassFX as a digital safebox located inside your user directory (`~/.pas
 
 1.  **The Key:** Your master password (which we never store).
 2.  **The Lock:** PBKDF2 key derivation.
-3.  **The Walls:** AES-256-CBC encryption.
+3.  **The Walls:** Fernet authenticated encryption (AES-128-CBC with HMAC-SHA256).
 4.  **The Contents:** JSON data loaded into memory only when the safe is open.
 
 ---
@@ -84,7 +84,7 @@ sequenceDiagram
 1.  User inputs **Master Password**.
 2.  `CryptoManager` reads the **Salt** from disk.
 3.  **Key Derivation:** We run the password + salt through **PBKDF2-HMAC-SHA256** (480,000 iterations). This burns CPU cycles to make brute-forcing expensive.
-4.  **Decryption:** The derived key opens the `vault.enc` file via **Fernet** (AES-256-CBC).
+4.  **Decryption:** The derived key opens the `vault.enc` file via **Fernet** (AES-128-CBC with HMAC-SHA256 authenticated encryption).
 5.  **Inflation:** The decrypted JSON bytes are parsed into Python objects (`EmailCredential`, etc.) and reside in **System RAM**.
 
 ### B. Saving a Credential

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,7 +25,7 @@ This is the initial public release of PassFX. It includes the core architecture,
 ### Added
 
 - **Core Security:**
-  - AES-256-CBC encryption via `cryptography.fernet`.
+  - Fernet authenticated encryption (AES-128-CBC + HMAC-SHA256) via `cryptography.fernet`.
   - PBKDF2-HMAC-SHA256 key derivation with 480,000 iterations.
   - Zero-knowledge architecture with separate salt storage.
 - **Terminal UI (TUI):**

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -40,7 +40,7 @@ To help you focus your research, here is what we consider in-scope and out-of-sc
 
 ### In Scope (We want to know about these)
 
-- **Cryptographic Weaknesses:** Flaws in our implementation of Fernet (AES-256-CBC) or PBKDF2.
+- **Cryptographic Weaknesses:** Flaws in our implementation of Fernet (AES-128-CBC with HMAC-SHA256) or PBKDF2.
 - **Data Leaks:** Credentials appearing in logs, unencrypted swap, or persisting in memory after a "lock" event.
 - **Side-Channel Attacks:** Timing attacks on password verification or key derivation.
 - **Injection:** TUI rendering bugs that allow arbitrary code execution via malicious payloads.
@@ -114,7 +114,7 @@ PassFX uses native Windows Security APIs via `ctypes` to set Discretionary Acces
 │                    PassFX Security Layers                        │
 ├─────────────────────────────────────────────────────────────────┤
 │  Layer 1: Encryption at Rest                                     │
-│  ├── AES-256-CBC (Fernet)                                       │
+│  ├── Fernet (AES-128-CBC + HMAC-SHA256)                         │
 │  ├── PBKDF2-HMAC-SHA256 (480,000 iterations)                    │
 │  └── 32-byte cryptographic salt                                 │
 ├─────────────────────────────────────────────────────────────────┤

--- a/passfx/core/crypto.py
+++ b/passfx/core/crypto.py
@@ -1,6 +1,6 @@
 """Cryptographic operations for PassFX vault encryption.
 
-Uses Fernet (AES-256-CBC) with PBKDF2 key derivation for secure encryption.
+Uses Fernet authenticated encryption (AES-128-CBC + HMAC-SHA256) with PBKDF2 key derivation.
 """
 
 from __future__ import annotations

--- a/passfx/screens/help.py
+++ b/passfx/screens/help.py
@@ -66,8 +66,8 @@ LEGEND_CONTENT = """\
 
 SYSTEM_CONTENT = """\
 [bold #00d4ff]> ENCRYPTION PROTOCOL[/]
-  [bold #8b5cf6]CIPHER[/]       [#22c55e]AES-256-CBC[/]
-                 [dim #64748b]256-bit key, CBC mode[/]
+  [bold #8b5cf6]CIPHER[/]       [#22c55e]Fernet (AES-128-CBC)[/]
+                 [dim #64748b]128-bit AES, CBC mode[/]
 
   [bold #8b5cf6]INTEGRITY[/]    [#22c55e]HMAC-SHA256[/]
                  [dim #64748b]Message authentication[/]


### PR DESCRIPTION
## Summary

Fixes three critical blocking issues identified in the Day 7 Final Security Verification Report:
- Weak master password enforcement during vault creation
- Non-persistent rate limiting that resets on application restart
- Incorrect cryptography documentation claiming AES-256 when Fernet uses AES-128

## Motivation

These three issues were classified as CRITICAL blockers preventing release:
1. **Password Policy**: `validate_master_password()` existed but was never called
2. **Rate Limiting**: In-memory counter enabled unlimited brute-force via restarts
3. **Documentation**: AES-256 overclaims could mislead security auditors

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure / CI / tooling
- [ ] Refactoring (no functional changes)

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] N/A (documentation only)

**Verification performed:**
- `ruff check passfx/` - PASSED
- `bandit -r passfx/ -ll` - PASSED (0 issues)
- `pylint` - 10.0/10 score
- All pre-commit hooks pass

## Risk Assessment

**Risk level:** Low

**Areas affected:**
- `passfx/screens/login.py` - vault creation and unlock flow
- Documentation files (README, SECURITY, ARCHITECTURE, CHANGELOG, help.py)

## Security Considerations

- [x] No credentials or secrets exposed
- [x] Sensitive data properly cleared from memory
- [x] File permissions verified (0600/0700)
- [ ] N/A (no security-sensitive changes)

**Security improvements:**
- Lockout state stored at `~/.passfx/lockout.json` with 0600 permissions
- Exponential backoff prevents brute-force (2^n seconds, max 1 hour)
- Atomic file writes with corruption handling

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes (pre-existing warnings in unrelated files)
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format