### PR TITLE
chore(quality): fix lint warnings

### DIFF
--- a/passfx/screens/login.py
+++ b/passfx/screens/login.py
@@ -77,7 +77,7 @@ def _get_lockout_state() -> dict:
         # Validate types
         if not isinstance(failed_attempts, int) or failed_attempts < 0:
             failed_attempts = 0
-        if lockout_until is not None and not isinstance(lockout_until, (int, float)):
+        if lockout_until is not None and not isinstance(lockout_until, int | float):
             lockout_until = None
 
         return {"failed_attempts": failed_attempts, "lockout_until": lockout_until}

--- a/passfx/utils/clipboard.py
+++ b/passfx/utils/clipboard.py
@@ -43,7 +43,7 @@ def copy_to_clipboard(
     global _active_timer  # pylint: disable=global-statement
 
     try:
-        import pyperclip  # type: ignore[import-untyped]
+        import pyperclip
 
         pyperclip.copy(text)
 


### PR DESCRIPTION
## Summary
- Use PEP 604 union syntax in `isinstance` call (UP038 lint fix)
- Remove unnecessary `type: ignore` comment for pyperclip import

## Changes
- `passfx/screens/login.py`: Changed `isinstance(lockout_until, (int, float))` to `isinstance(lockout_until, int | float)`
- `passfx/utils/clipboard.py`: Removed `# type: ignore[import-untyped]` comment

## Test plan
- [x] Pre-commit hooks pass
- [x] Ruff check passes (UP038 resolved)
- [ ] CI pipeline validation