### PR TITLE
fix(codecov): correct ignore patterns to match flat directory structure

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -46,9 +46,13 @@ flags:
 # UI modules excluded - coverage focuses on security-critical code
 # (core crypto, vault, models, utils). UI rendering tests add
 # complexity without improving security guarantees.
+#
+# Pattern notes (from Codecov docs):
+# - "path/to/folder" ignores folder and ALL contents (recursive)
+# - "**/*" requires at least one subdirectory level (won't match direct children)
 ignore:
   - "passfx/__main__.py"
   - "**/__init__.py"
-  - "passfx/screens/**/*"
-  - "passfx/ui/**/*"
-  - "passfx/widgets/**/*"
+  - "passfx/screens"
+  - "passfx/ui"
+  - "passfx/widgets"


### PR DESCRIPTION
## Summary

Fix Codecov ignore patterns that were failing to exclude UI modules (screens, ui, widgets) from coverage calculation.

## Motivation

The previous patterns (`passfx/screens/**/*`) required at least one subdirectory level due to how Codecov converts glob patterns to regex. Since files like `passfx/screens/login.py` are directly in those folders (not in subdirectories), they were not being excluded from coverage reports.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure / CI / tooling
- [ ] Refactoring (no functional changes)

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] N/A (documentation only)

**Validation performed:**
- Verified patterns via Codecov validation endpoint (`curl --data-binary @codecov.yml https://codecov.io/validate`)
- Confirmed regex conversion:
  - `"passfx/screens"` → `^passfx/screens.*` (matches all contents)
  - Previous `"passfx/screens/**/*"` → `(?s:passfx/screens/.*/[^\/]*)\Z` (required subdirectory)

## Risk Assessment

**Risk level:** Low

**Areas affected:**
- Codecov coverage reporting only
- No changes to application code

## Security Considerations

- [x] N/A (no security-sensitive changes)

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format