### PR TITLE
fix(coverage): exclude platform-specific code from coverage calculation

### DIFF
--- a/passfx/utils/platform_security.py
+++ b/passfx/utils/platform_security.py
@@ -28,7 +28,7 @@ class PlatformSecurityError(Exception):
 
 
 # Windows-specific implementation
-def _get_current_user_sid_windows() -> (
+def _get_current_user_sid_windows() -> (  # pragma: no cover
     tuple[ctypes.c_void_p, int]
 ):  # pylint: disable=import-outside-toplevel
     """Get the current user's SID on Windows.
@@ -152,7 +152,7 @@ def _get_current_user_sid_windows() -> (
             kernel32.CloseHandle(token_handle)
 
 
-def _set_windows_acl(  # pylint: disable=import-outside-toplevel
+def _set_windows_acl(  # pragma: no cover  # pylint: disable=import-outside-toplevel
     path: Path,
     is_directory: bool = False,
 ) -> None:
@@ -362,7 +362,7 @@ def secure_file_permissions(path: Path) -> None:
         logger.warning("Cannot set permissions on non-existent file: %s", path)
         return
 
-    if sys.platform == "win32":
+    if sys.platform == "win32":  # pragma: no cover
         try:
             _set_windows_acl(path, is_directory=False)
             logger.debug("Set Windows ACL for file: %s", path)
@@ -394,7 +394,7 @@ def secure_directory_permissions(path: Path) -> None:
         logger.warning("Cannot set permissions on non-existent directory: %s", path)
         return
 
-    if sys.platform == "win32":
+    if sys.platform == "win32":  # pragma: no cover
         try:
             _set_windows_acl(path, is_directory=True)
             logger.debug("Set Windows ACL for directory: %s", path)
@@ -469,7 +469,7 @@ def get_platform_security_notes() -> list[str]:
                 "macOS: Keychain integration is not used; secrets are file-based.",
             ]
         )
-    else:  # Linux and other Unix
+    else:  # Linux and other Unix  # pragma: no cover
         notes.extend(
             [
                 "Linux: File permissions enforced via standard Unix mode bits.",


### PR DESCRIPTION
## Summary

Add `# pragma: no cover` comments to platform-specific code paths in `platform_security.py` that cannot be executed on macOS test runners.

## Motivation

The `platform_security.py` module had only 34% coverage because ~65% of the code is Windows-specific (ctypes.windll calls) that cannot execute on macOS/Linux. This is expected behavior for cross-platform code, but it skews coverage metrics.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure / CI / tooling
- [ ] Refactoring (no functional changes)

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] N/A (documentation only)

**Verification:**
- Ran `pytest tests/utils/test_platform.py --cov=passfx.utils.platform_security`
- Coverage: 34% → 100%
- All 52 tests pass, 1 skipped (Linux-specific)

## Risk Assessment

**Risk level:** Low

**Areas affected:**
- Coverage reporting only
- No functional code changes

## Security Considerations

- [x] N/A (no security-sensitive changes)

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes (pre-existing issue in strength.py unrelated)
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format

## Code Excluded from Coverage

| Location | Reason |
|----------|--------|
| `_get_current_user_sid_windows()` | Windows-only ctypes/Security API |
| `_set_windows_acl()` | Windows DACL manipulation |
| `secure_file_permissions()` win32 branch | Calls Windows-only function |
| `secure_directory_permissions()` win32 branch | Calls Windows-only function |
| `get_platform_security_notes()` Linux branch | Only executes on Linux |