### PR TITLE
docs(agents): add PR template file path reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Claude must **ALWAYS** follow this exact workflow — no deviations:
 
 6. **After committing**
    - Always create a PR
-   - Use the github PR template and fill it out
+   - Use the github PR template and fill it out (.github/pull_request_template.md)
    - Do **NOT** mention Claude or AI when filling out the PR template
 
 🚫 **Hard Rules**


### PR DESCRIPTION
## Summary

Add explicit file path reference for the PR template in the agents guide.

## Motivation

Clarifies where to find the PR template file (.github/pull_request_template.md) for easier navigation.

## Type of Change

- [x] Documentation update

## Testing

- [x] N/A (documentation only)

## Risk Assessment

**Risk level:** Low

**Areas affected:** Documentation only

## Security Considerations

- [x] N/A (no security-sensitive changes)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code for obvious issues
- [x] Commit messages follow conventional format