### PR TITLE
feat(ui): refactor main menu to Operator cyberpunk aesthetic

### DIFF
--- a/passfx/screens/main_menu.py
+++ b/passfx/screens/main_menu.py
@@ -24,11 +24,9 @@ from passfx.widgets.terminal import SystemTerminal
 if TYPE_CHECKING:
     from passfx.app import PassFXApp
 
-# Compact sidebar logo
-SIDEBAR_LOGO = """[bold #00d4ff]╔══════════════════════╗
-║  P A S S F X  ║
-║  COMMAND CENTER  ║
-╚══════════════════════╝[/]"""
+# Compact ASCII Logo - 3 lines
+HEADER_LOGO = """[bold #00FFFF]█▀█ ▄▀█ █▀ █▀ █▀▀ ▀▄▀
+█▀▀ █▀█ ▄█ ▄█ █▀  █ █[/]"""
 
 VERSION = "v1.0.0"
 
@@ -62,7 +60,7 @@ class SecurityScore(Static):
         num_segments = 20
         filled = int((health.overall_score / 100) * num_segments)
         empty = num_segments - filled
-        bar_str = f"[{score_color}]{'▮' * filled}[/][dim #222222]{'·' * empty}[/]"
+        bar_str = f"[{score_color}]{'█' * filled}[/][#333333]{'░' * empty}[/]"
         lines.append(f"{bar_str}  [bold {score_color}]{health.overall_score}%[/]")
         lines.append("")  # Breathing room
 
@@ -85,14 +83,14 @@ class SecurityScore(Static):
         self.update("\n".join(lines))
 
     def _get_score_color(self, score: int) -> str:
-        """Get color based on security score."""
+        """Get color based on security score - Operator theme."""
         if score >= 80:
-            return "#22c55e"
+            return "#00FFFF"  # Operator primary (cyan)
         if score >= 60:
-            return "#60a5fa"
+            return "#00cc99"  # Teal
         if score >= 40:
-            return "#f59e0b"
-        return "#ef4444"
+            return "#8b5cf6"  # Operator secondary (purple)
+        return "#ef4444"  # Error red
 
     def _build_histogram(self, health: VaultHealthResult) -> list[str]:
         """Build strength distribution histogram."""
@@ -125,20 +123,21 @@ class SecurityScore(Static):
 
 
 def _make_menu_item(code: str, label: str) -> Text:
-    """Create a menu item with fixed-width icon and label columns.
+    """Create a menu item with Operator theme [ ] prefix decorators.
 
     Args:
         code: The short code (e.g., "KEY", "PIN")
         label: The menu item label
 
     Returns:
-        Rich Text object with consistent formatting
+        Rich Text object with [ CODE ] prefix decoration
     """
     text = Text()
-    # Icon part: Cyan/Blue, fixed width 7 chars, centered
-    text.append(f"{code:^7}", style="bold #3b82f6")
-    # Label part: White, bold
-    text.append(f" {label}", style="bold white")
+    # Operator theme: [ ] prefix with cyan accent
+    text.append("[", style="bold #00FFFF")
+    text.append(f"{code:^5}", style="bold #00FFFF")
+    text.append("]", style="bold #00FFFF")
+    text.append(f" {label}", style="white")
     return text
 
 
@@ -154,17 +153,17 @@ class MainMenuScreen(Screen):
 
     def compose(self) -> ComposeResult:  # pylint: disable=too-many-statements
         """Create the command center layout."""
-        # Custom header - System Status Bar with live telemetry
+        # Command Bar - Operator theme header with ASCII logo
         with Horizontal(id="app-header"):
-            yield Static("[bold #00d4ff]◄ PASSFX ►[/]", id="header-branding")
-            yield Static("░░ SECURITY COMMAND CENTER ░░", id="header-status")
-            yield Static("", id="header-clock")
-            yield Static("🔓 DECRYPTED", id="header-lock")
+            yield Static(HEADER_LOGO, id="header-branding")
+            with Horizontal(id="header-right"):
+                yield Static("", id="header-clock")
+                yield Static("[dim]│[/] [#22c55e]DECRYPTED[/]", id="header-lock")
 
         with Horizontal(id="main-container"):
             # Left pane: Navigation sidebar
-            with Vertical(id="sidebar"):
-                yield Static(SIDEBAR_LOGO, id="sidebar-logo")
+            with Vertical(id="sidebar") as sidebar:
+                sidebar.border_title = "COMMAND CENTRE"
                 yield OptionList(
                     Option(_make_menu_item("KEY", "Passwords"), id="passwords"),
                     Option(_make_menu_item("PIN", "Phones"), id="phones"),
@@ -182,7 +181,7 @@ class MainMenuScreen(Screen):
             # Right pane: Dashboard view (scrollable for smaller screens)
             with VerticalScroll(id="dashboard-view"):
                 yield Static(
-                    "[bold #60a5fa]━━━ VAULT STATUS ━━━[/]",
+                    "[bold #00FFFF][ VAULT STATUS ][/]",
                     id="dashboard-title",
                 )
 
@@ -232,23 +231,23 @@ class MainMenuScreen(Screen):
             # Right segment: Key hints as mechanical keycaps
             with Horizontal(id="footer-keys"):
                 with Horizontal(classes="keycap-group"):
-                    yield Static("[bold #a78bfa] ↑↓ [/]", classes="keycap")
-                    yield Static("[#64748b]Navigate[/]", classes="keycap-label")
+                    yield Static("[bold #00FFFF] ↑↓ [/]", classes="keycap")
+                    yield Static("[#666666]Navigate[/]", classes="keycap-label")
                 with Horizontal(classes="keycap-group"):
-                    yield Static("[bold #a78bfa] ⏎ [/]", classes="keycap")
-                    yield Static("[#64748b]Select[/]", classes="keycap-label")
+                    yield Static("[bold #00FFFF] ENTER [/]", classes="keycap")
+                    yield Static("[#666666]Select[/]", classes="keycap-label")
                 with Horizontal(classes="keycap-group"):
-                    yield Static("[bold #a78bfa] / [/]", classes="keycap")
-                    yield Static("[#64748b]Terminal[/]", classes="keycap-label")
+                    yield Static("[bold #00FFFF] / [/]", classes="keycap")
+                    yield Static("[#666666]Terminal[/]", classes="keycap-label")
                 with Horizontal(classes="keycap-group"):
-                    yield Static("[bold #a78bfa] ESC [/]", classes="keycap")
-                    yield Static("[#64748b]Back[/]", classes="keycap-label")
+                    yield Static("[bold #00FFFF] ESC [/]", classes="keycap")
+                    yield Static("[#666666]Back[/]", classes="keycap-label")
                 with Horizontal(classes="keycap-group"):
-                    yield Static("[bold #a78bfa] ? [/]", classes="keycap")
-                    yield Static("[#64748b]Help[/]", classes="keycap-label")
+                    yield Static("[bold #00FFFF] ? [/]", classes="keycap")
+                    yield Static("[#666666]Help[/]", classes="keycap-label")
                 with Horizontal(classes="keycap-group"):
-                    yield Static("[bold #a78bfa] Q [/]", classes="keycap")
-                    yield Static("[#64748b]Quit[/]", classes="keycap-label")
+                    yield Static("[bold #00FFFF] Q [/]", classes="keycap")
+                    yield Static("[#666666]Quit[/]", classes="keycap-label")
 
     def on_mount(self) -> None:
         """Initialize dashboard data on mount."""

--- a/passfx/styles/passfx.tcss
+++ b/passfx/styles/passfx.tcss
@@ -26,6 +26,14 @@ $deep-black: #050505;
 $terminal-dim: #444444;
 $surface-black: #0a0a0a;
 
+/* Operator Theme Tokens - Pure black cyberpunk aesthetic */
+$operator-black: #000000;
+$operator-primary: #00FFFF;
+$operator-secondary: #8b5cf6;
+$operator-surface: #0a0a0a;
+$operator-text: #e0e0e0;
+$operator-muted: #666666;
+
 /* ═══════════════════════════════════════════════════════════════════════════
    GLOBAL STYLES
    ═══════════════════════════════════════════════════════════════════════════ */
@@ -35,52 +43,58 @@ Screen {
     color: $pfx-fg;
 }
 
+/* Main Menu uses pure black Operator theme */
+MainMenuScreen {
+    background: $operator-black;
+}
+
 /* ═══════════════════════════════════════════════════════════════════════════
    CUSTOM HEADER - SYSTEM STATUS BAR
    ═══════════════════════════════════════════════════════════════════════════ */
 
+/* COMMAND BAR - Operator Theme Header with ASCII Logo */
 #app-header {
     width: 100%;
-    height: 3;
+    height: 4;
     dock: top;
-    background: #0f172a;
-    align: center middle;
+    background: $operator-black;
+    border-bottom: heavy $operator-secondary;
+    align: left middle;
 }
 
 #header-branding {
     width: auto;
-    min-width: 28;
-    height: 100%;
-    background: #0f172a;
-    color: #00d4ff;
-    text-style: bold;
+    height: 4;
+    background: $operator-black;
+    color: $operator-primary;
     content-align: left middle;
-    padding-left: 1;
+    padding: 1 2;
 }
 
-#header-status {
+#header-right {
     width: 1fr;
-    height: 100%;
-    color: #475569;
-    content-align: center middle;
+    height: 4;
+    background: $operator-black;
+    align: right middle;
+    padding: 0 2;
 }
 
 #header-clock {
     width: auto;
-    height: 100%;
-    color: #60a5fa;
+    height: auto;
+    color: $operator-primary;
     text-style: bold;
-    padding: 0 2;
-    content-align: center middle;
+    content-align: right middle;
+    background: $operator-black;
 }
 
 #header-lock {
     width: auto;
-    height: 100%;
-    color: #22c55e;
+    height: auto;
+    color: $pfx-success;
     text-style: bold;
-    padding-right: 1;
-    content-align: center middle;
+    content-align: right middle;
+    background: $operator-black;
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
@@ -112,14 +126,15 @@ FooterKey > .footer-key--description {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
-   CUSTOM FOOTER - GRID-ALIGNED COMMAND STRIP
+   CUSTOM FOOTER - Operator Theme Command Strip
    ═══════════════════════════════════════════════════════════════════════════ */
 
 #app-footer {
     width: 100%;
     height: 3;
     dock: bottom;
-    background: #0f172a;
+    background: $operator-black;
+    border-top: heavy $operator-secondary;
     align: center middle;
     padding: 0;
     margin: 0;
@@ -127,40 +142,43 @@ FooterKey > .footer-key--description {
 
 #footer-version {
     width: 28;
-    height: 100%;
-    background: #0a0e27;
-    color: #475569;
+    height: 3;
+    background: $operator-black;
+    color: $operator-muted;
     content-align: center middle;
 }
 
 #footer-keys {
     width: 1fr;
-    height: 100%;
-    background: #0f172a;
+    height: 3;
+    background: $operator-black;
     align: left middle;
     padding-left: 2;
 }
 
-/* Mechanical Keycap Styling */
+/* Mechanical Keycap Styling - Operator Theme */
 .keycap-group {
     width: auto;
-    height: 1;
+    height: auto;
     margin-right: 2;
 }
 
 .keycap {
     width: auto;
-    height: 1;
-    min-width: 3;
-    background: #334155;
+    height: auto;
+    min-width: 5;
+    background: $operator-surface;
+    color: $operator-primary;
+    text-style: bold;
     padding: 0 1;
 }
 
 .keycap-label {
     width: auto;
-    height: 1;
+    height: auto;
     background: transparent;
     margin-left: 1;
+    color: $operator-muted;
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
@@ -305,17 +323,16 @@ LoginScreen {
     align: left top;
 }
 
+/* SECTOR GRID - Navigation Sidebar Operator Theme */
 #sidebar {
     width: 28;
     height: 100%;
-    background: #0f172a;
-    padding: 1 0;
-}
-
-#sidebar-logo {
-    text-align: center;
-    padding: 1 0;
-    margin-bottom: 1;
+    background: $operator-black;
+    padding: 1 1 0 1;
+    border: solid $operator-primary 30%;
+    border-title-align: center;
+    border-title-color: $operator-primary;
+    border-title-style: bold;
 }
 
 #sidebar-menu {
@@ -330,17 +347,32 @@ LoginScreen {
     border: none;
 }
 
-#sidebar-menu > .option-list--option-highlighted {
-    background: #3b82f6;
-    color: #0f172a;
-    text-style: bold;
+/* Navigation items - default state */
+#sidebar-menu > .option-list--option {
+    padding-left: 2;
+    color: $operator-text;
 }
 
-/* Dashboard View - Scrollable Container */
+/* Active/Highlighted state with left border glow */
+#sidebar-menu > .option-list--option-highlighted {
+    background: #0a2a2a;
+    color: #00FFFF;
+    text-style: bold;
+    border-left: heavy #00FFFF;
+    padding-left: 1;
+}
+
+/* Hover state */
+#sidebar-menu > .option-list--option-hover {
+    background: #1a1a2e;
+    color: #FFFFFF;
+}
+
+/* Dashboard View - Operator Theme */
 #dashboard-view {
     width: 1fr;
     height: 100%;
-    background: #1e293b;
+    background: $operator-black;
     padding: 0 2 1 2;
     scrollbar-gutter: stable;
 }
@@ -351,44 +383,46 @@ LoginScreen {
 
 #dashboard-title {
     text-align: center;
-    padding: 1 0;
-    margin-top: 1;
-    margin-bottom: 1;
+    padding: 0;
+    margin: 0;
     height: auto;
+    color: $operator-primary;
+    display: none;
 }
 
-/* Stats HUD Strip - Hardware Panel Look */
+/* Stats HUD Strip - Operator Theme */
 #stats-strip,
 #stats-strip-2 {
     width: 100%;
     height: 2fr;
     max-height: 10;
-    background: #0a0e27;
+    background: $operator-black;
+    border: solid $operator-primary 50%;
     padding: 0;
 }
 
 #stats-strip {
-    margin: 1 0 0 0;
+    margin: 0;
 }
 
 #stats-strip-2 {
     margin: 0 0 1 0;
-    border-top: solid #1e293b;
+    border-top: none;
 }
 
-/* Stat Segment - Responsive Card Design */
+/* Stat Segment - Operator Theme */
 .stat-segment {
     width: 1fr;
     min-width: 12;
     height: 100%;
     align: center middle;
     padding: 0 1;
-    border-right: solid #334155;
+    border-right: solid $operator-primary 30%;
     background: transparent;
 }
 
 .stat-segment:hover {
-    background: #1e3a5f;
+    background: $operator-surface;
 }
 
 .stat-segment:last-child {
@@ -396,7 +430,7 @@ LoginScreen {
 }
 
 .stat-label {
-    color: $pfx-muted;
+    color: $operator-muted;
     text-style: bold;
     text-align: center;
     height: 1;
@@ -446,15 +480,32 @@ LoginScreen {
     overflow: hidden;
 }
 
-/* CRT-style dashboard panels - deep recessed screen effect */
+/* HUD CARDS - Operator Theme Panels */
+.hud-card {
+    background: $operator-black;
+    border: solid $operator-primary;
+    border-title-align: center;
+    border-title-color: $operator-primary;
+    border-title-style: bold;
+    border-title-background: $operator-black;
+    padding: 1;
+    margin: 1;
+}
+
+.hud-card:focus {
+    border: solid $operator-secondary;
+}
+
+/* CRT-style dashboard panels - Operator Theme */
 .gauge-panel {
     width: 1fr;
     height: 100%;
-    background: #000000;
-    border: heavy $pfx-primary-dim;
-    border-title-color: $pfx-primary-light;
+    background: $operator-black;
+    border: solid $operator-primary;
+    border-title-align: center;
+    border-title-color: $operator-primary;
     border-title-style: bold;
-    border-title-background: #000000;
+    border-title-background: $operator-black;
     padding: 1 2;
     margin: 1 1 1 0;
     text-align: center;
@@ -463,11 +514,12 @@ LoginScreen {
 .log-panel {
     width: 1fr;
     height: 100%;
-    background: #000000;
-    border: heavy $pfx-accent-dim;
-    border-title-color: $pfx-accent;
+    background: $operator-black;
+    border: solid $operator-secondary;
+    border-title-align: center;
+    border-title-color: $operator-secondary;
     border-title-style: bold;
-    border-title-background: #000000;
+    border-title-background: $operator-black;
     padding: 1 2;
     margin: 1 0 1 1;
     text-align: left;
@@ -3293,7 +3345,7 @@ Button.note-delete-btn:focus {
    Theme: Purple/Violet (#8b5cf6) for System Commands
    ═══════════════════════════════════════════════════════════════════════════════ */
 
-/* Terminal Container - constrained to fit log-panel */
+/* SYSTEM TERMINAL - Operator Theme */
 #system-terminal {
     width: 1fr;
     max-width: 100%;
@@ -3308,8 +3360,8 @@ Button.note-delete-btn:focus {
     width: 1fr;
     max-width: 100%;
     height: 1fr;
-    background: #000000;
-    color: $pfx-fg;
+    background: $operator-black;
+    color: $operator-text;
     border: none;
     padding: 0;
     overflow-x: hidden;
@@ -3325,24 +3377,24 @@ Button.note-delete-btn:focus {
     width: 1fr;
     max-width: 100%;
     height: 1;
-    background: #000000;
+    background: $operator-black;
     align: left middle;
     padding: 0;
     dock: bottom;
 }
 
-/* Terminal Prompt - Arrow indicator */
+/* Terminal Prompt - Operator theme arrow */
 .terminal-prompt,
 #terminal-prompt {
     width: auto;
     height: 1;
-    color: $pfx-success;
+    color: $operator-primary;
     text-style: bold;
     background: transparent;
     padding: 0;
 }
 
-/* Terminal Input - Command text entry (terminal style) */
+/* Terminal Input - Command text entry (Operator theme) */
 #terminal-input {
     width: 1fr;
     height: 1;
@@ -3350,7 +3402,7 @@ Button.note-delete-btn:focus {
     border: none;
     padding: 0;
     margin: 0;
-    color: $pfx-fg;
+    color: $operator-text;
 }
 
 #terminal-input:focus {
@@ -3359,10 +3411,11 @@ Button.note-delete-btn:focus {
 }
 
 #terminal-input > .input--placeholder {
-    color: #475569;
+    color: $operator-muted;
 }
 
+/* Block cursor effect */
 #terminal-input > .input--cursor {
-    background: $pfx-success;
-    color: $pfx-bg;
+    background: $operator-primary;
+    color: $operator-black;
 }

--- a/passfx/widgets/terminal.py
+++ b/passfx/widgets/terminal.py
@@ -43,7 +43,7 @@ class SystemTerminal(Vertical, can_focus=True):
             auto_scroll=True,
         )
         with Horizontal(id="terminal-input-row"):
-            yield Label("➜", id="terminal-prompt", classes="terminal-prompt")
+            yield Label(">", id="terminal-prompt", classes="terminal-prompt")
             yield Input(
                 placeholder="",
                 id="terminal-input",


### PR DESCRIPTION
## Summary

Refactor the main menu screen to match the "Operator" cyberpunk aesthetic established in the Night City login theme. This is a visual-only change with no business logic modifications.

Key changes:
- Pure black background (#000000) with neon cyan (#00FFFF) and purple (#8b5cf6) accents
- Compact ASCII PASSFX logo in header
- "COMMAND CENTRE" bordered sidebar with left-glow active state highlights
- Sharp HUD-style dashboard panels with centered titles
- Mechanical keycap footer styling (↑↓ Navigate, ENTER Select, ESC Back)
- Terminal prompt changed from "➜" to ">"

## Motivation

Creates visual consistency between the login screen and main menu, completing the Operator cyberpunk theme across the application.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure / CI / tooling
- [x] Refactoring (no functional changes)

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] N/A (documentation only)

Manually verified:
- Header displays ASCII logo with clock and DECRYPTED status on single line
- Sidebar shows "COMMAND CENTRE" title with bordered panel
- Navigation highlights with left cyan border glow
- Footer keycaps render correctly without clipping
- All screens accessible via keyboard navigation

## Risk Assessment

**Risk level:** Low

**Areas affected:**
- `passfx/styles/passfx.tcss` - Visual styles only
- `passfx/screens/main_menu.py` - Layout structure, no logic changes
- `passfx/widgets/terminal.py` - Prompt character only

## Security Considerations

- [x] N/A (no security-sensitive changes)

Visual-only changes. No credentials, encryption, or vault logic affected.

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format