### PR TITLE
feat(ui): refactor Phones screen to Operator cyberpunk aesthetic

### DIFF
--- a/passfx/screens/phones.py
+++ b/passfx/screens/phones.py
@@ -70,30 +70,6 @@ def _get_relative_time(iso_timestamp: str | None) -> str:
         return "-"
 
 
-def _get_avatar_initials(label: str) -> str:
-    """Generate 2-character avatar initials from label.
-
-    Args:
-        label: Service/site label.
-
-    Returns:
-        2-character uppercase initials.
-    """
-    if not label:
-        return "??"
-
-    # Clean and split
-    words = label.replace("_", " ").replace("-", " ").split()
-
-    if len(words) >= 2:
-        # First letter of first two words
-        return (words[0][0] + words[1][0]).upper()
-    if len(label) >= 2:
-        # First two characters
-        return label[:2].upper()
-    return (label[0] + label[0]).upper() if label else "??"
-
-
 def _get_strength_color(score: int) -> str:
     """Get hex color for strength score.
 
@@ -111,32 +87,6 @@ def _get_strength_color(score: int) -> str:
         4: "#22c55e",  # Green - Strong
     }
     return colors.get(score, "#94a3b8")
-
-
-def _get_avatar_bg_color(label: str) -> str:
-    """Generate a consistent background color for avatar based on label.
-
-    Args:
-        label: Service/site label.
-
-    Returns:
-        Hex color string.
-    """
-    # Simple hash-based color selection
-    colors = [
-        "#3b82f6",  # Blue
-        "#8b5cf6",  # Purple
-        "#06b6d4",  # Cyan
-        "#10b981",  # Emerald
-        "#f59e0b",  # Amber
-        "#ec4899",  # Pink
-        "#6366f1",  # Indigo
-        "#14b8a6",  # Teal
-    ]
-    if not label:
-        return colors[0]
-    hash_val = sum(ord(c) for c in label)
-    return colors[hash_val % len(colors)]
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -466,62 +416,87 @@ class PhonesScreen(Screen):
         Binding("escape", "back", "Back"),
     ]
 
+    # Operator theme color tokens - Pink accent for phones
+    COLORS = {
+        "primary": "#00FFFF",  # Cyan - active selection, titles
+        "accent": "#ec4899",  # Pink - labels, headers (phones-specific)
+        "success": "#22c55e",  # Green - high strength, decrypted
+        "muted": "#666666",  # Dim grey - metadata, timestamps
+        "text": "#e0e0e0",  # Light text
+        "surface": "#0a0a0a",  # Dark surface
+    }
+
     def __init__(self) -> None:
         super().__init__()
         self._selected_row_key: str | None = None
         self._pulse_state: bool = True
 
+    # pylint: disable=too-many-locals
     def compose(self) -> ComposeResult:
         """Create the phones screen layout."""
-        # 1. Global Header with Breadcrumbs
+        c = self.COLORS
+
+        # 1. Global Header with Breadcrumbs - Operator theme
         with Horizontal(id="app-header"):
-            breadcrumb = (
-                "[dim #64748b]HOME[/] [#475569]›[/] "
-                "[dim #64748b]VAULT[/] [#475569]›[/] "
-                "[bold #8b5cf6]PHONES[/]"
+            yield Static(
+                f"[bold {c['primary']}]VAULT // COMMS[/]",
+                id="header-branding",
+                classes="screen-header",
             )
-            yield Static(breadcrumb, id="header-branding")
-            yield Static("░░ SECURE COMMS BANK ░░", id="header-status")
-            yield Static("", id="header-lock")  # Will be updated with pulse
+            with Horizontal(id="header-right"):
+                yield Static("", id="header-lock")  # Will be updated with pulse
 
         # 2. Body (Master-Detail Split)
         with Horizontal(id="vault-body"):
             # Left Pane: Data Grid (Master) - 65%
             with Vertical(id="vault-grid-pane"):
-                # Inverted Block Header
-                yield Static(" ≡ SECURE_COMMS_DB ", classes="pane-header-block-purple")
                 yield DataTable(id="phones-table", cursor_type="row")
                 # Empty state placeholder (hidden by default)
                 with Center(id="empty-state"):
                     yield Static(
-                        "[dim #475569]╔══════════════════════════════════════╗\n"
+                        f"[dim {c['muted']}]╔══════════════════════════════════════╗\n"
                         "║                                      ║\n"
                         "║      NO ENTRIES FOUND                ║\n"
                         "║                                      ║\n"
-                        "║      INITIATE SEQUENCE [A]           ║\n"
+                        f"║      INITIATE SEQUENCE [{c['primary']}]A[/]           ║\n"
                         "║                                      ║\n"
                         "╚══════════════════════════════════════╝[/]",
                         id="empty-state-text",
                     )
                 # Footer with object count
                 yield Static(
-                    " └── UPLINK_ESTABLISHED", classes="pane-footer", id="grid-footer"
+                    " └── SYSTEM_READY", classes="pane-footer", id="grid-footer"
                 )
 
             # Right Pane: Inspector (Detail) - 35%
             with Vertical(id="vault-inspector"):
-                # Inverted Block Header
-                yield Static(" ≡ DEVICE_INSPECTOR ", classes="pane-header-block-purple")
+                # Inverted Block Header - Pink accent
+                yield Static(" ≡ DEVICE_INSPECTOR ", classes="pane-header-block-pink")
                 yield Vertical(id="inspector-content")  # Dynamic content here
 
-        # 3. Global Footer
+        # 3. Global Footer - Mechanical keycap style
         with Horizontal(id="app-footer"):
-            yield Static(" VAULT ", id="footer-version")
-            footer_keys = (
-                " \\[A] Add  \\[C] Copy  \\[E] Edit  "
-                "\\[D] Delete  \\[V] View  \\[ESC] Back"
-            )
-            yield Static(footer_keys, id="footer-keys-static")
+            yield Static(f" [{c['accent']}]VAULT[/] ", id="footer-version")
+            with Horizontal(id="footer-keys"):
+                # Keycap groups for each command
+                with Horizontal(classes="keycap-group"):
+                    yield Static(f"[bold {c['primary']}] A [/]", classes="keycap")
+                    yield Static(f"[{c['muted']}]Add[/]", classes="keycap-label")
+                with Horizontal(classes="keycap-group"):
+                    yield Static(f"[bold {c['primary']}] C [/]", classes="keycap")
+                    yield Static(f"[{c['muted']}]Copy[/]", classes="keycap-label")
+                with Horizontal(classes="keycap-group"):
+                    yield Static(f"[bold {c['primary']}] E [/]", classes="keycap")
+                    yield Static(f"[{c['muted']}]Edit[/]", classes="keycap-label")
+                with Horizontal(classes="keycap-group"):
+                    yield Static(f"[bold {c['primary']}] D [/]", classes="keycap")
+                    yield Static(f"[{c['muted']}]Del[/]", classes="keycap-label")
+                with Horizontal(classes="keycap-group"):
+                    yield Static(f"[bold {c['primary']}] V [/]", classes="keycap")
+                    yield Static(f"[{c['muted']}]View[/]", classes="keycap-label")
+                with Horizontal(classes="keycap-group"):
+                    yield Static(f"[bold {c['primary']}] ESC [/]", classes="keycap")
+                    yield Static(f"[{c['muted']}]Back[/]", classes="keycap-label")
 
     def on_mount(self) -> None:
         """Initialize the data table."""
@@ -531,15 +506,26 @@ class PhonesScreen(Screen):
         # Start pulse animation
         self._update_pulse()
         self.set_interval(1.0, self._update_pulse)
+        # Start cursor blink animation
+        self.set_interval(0.5, self._blink_cursor)
+
+    def _blink_cursor(self) -> None:
+        """Toggle the blinking cursor visibility in empty notes."""
+        try:
+            cursor = self.query_one(".blink-cursor", Static)
+            cursor.toggle_class("-blink-off")
+        except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
+            pass  # Cursor may not exist if notes have content
 
     def _update_pulse(self) -> None:
         """Update the pulse indicator in the header."""
         self._pulse_state = not self._pulse_state
         header_lock = self.query_one("#header-lock", Static)
+        c = self.COLORS
         if self._pulse_state:
-            header_lock.update("[#d946ef]● [bold]ENCRYPTED[/][/]")
+            header_lock.update(f"[{c['success']}]● [bold]ENCRYPTED[/][/]")
         else:
-            header_lock.update("[#6b21a8]○ [bold]ENCRYPTED[/][/]")
+            header_lock.update(f"[#166534]○ [{c['success']}]ENCRYPTED[/][/]")
 
     def _initialize_selection(self) -> None:
         """Initialize table selection and inspector after render."""
@@ -563,16 +549,17 @@ class PhonesScreen(Screen):
         app: PassFXApp = self.app  # type: ignore
         table = self.query_one("#phones-table", DataTable)
         empty_state = self.query_one("#empty-state", Center)
+        c = self.COLORS
 
         table.clear(columns=True)
 
-        # Column layout - sized to fill available space
-        table.add_column("", width=3)  # Selection indicator column
-        table.add_column("Label", width=22)
-        table.add_column("Phone", width=22)
-        table.add_column("Status", width=10)
-        table.add_column("Updated", width=12)
-        table.add_column("Notes", width=40)  # Wider to fill remaining space
+        # Column layout - data stream style (matches passwords)
+        table.add_column("", width=2)  # Selection indicator column
+        table.add_column("DEVICE", width=22)
+        table.add_column("UPLINK", width=22)
+        table.add_column("LEVEL", width=10)
+        table.add_column("SYNC", width=12)
+        table.add_column("METADATA", width=40)
 
         credentials = app.vault.get_phones()
 
@@ -587,29 +574,30 @@ class PhonesScreen(Screen):
         for cred in credentials:
             # Selection indicator - will be updated dynamically
             is_selected = cred.id == self._selected_row_key
-            indicator = "[bold #8b5cf6]▍[/]" if is_selected else " "
+            indicator = f"[bold {c['primary']}]▸[/]" if is_selected else " "
 
-            # Label (white text)
+            # Label - primary text
             label_text = cred.label
 
-            # Phone (muted)
-            phone_text = f"[#94a3b8]{cred.phone}[/]"
+            # Phone (muted grey)
+            phone_text = f"[{c['muted']}]{cred.phone}[/]"
 
-            # Status column with colored lock icon based on PIN strength
+            # Status column with colored indicator based on PIN strength
             strength = check_strength(cred.password)
             color = _get_strength_color(strength.score)
-            status = f"[{color}]🔒[/]"
+            status = f"[{color}]●[/]"
 
-            # Relative time (dim)
+            # Relative time (dim muted)
             updated = _get_relative_time(cred.updated_at)
-            updated_text = f"[dim]{updated}[/]"
+            updated_text = f"[dim {c['muted']}]{updated}[/]"
 
             # Notes preview (dim)
-            if cred.notes and len(cred.notes) > 16:
-                notes = cred.notes[:16] + "…"
-            else:
-                notes = cred.notes or "-"
-            notes_text = f"[dim #64748b]{notes}[/]"
+            notes = (
+                (cred.notes[:16] + "…")
+                if cred.notes and len(cred.notes) > 16
+                else (cred.notes or "-")
+            )
+            notes_text = f"[dim {c['muted']}]{notes}[/]"
 
             table.add_row(
                 indicator,
@@ -624,7 +612,7 @@ class PhonesScreen(Screen):
         # Update the grid footer with object count
         footer = self.query_one("#grid-footer", Static)
         count = len(credentials)
-        footer.update(f" └── [{count}] UPLINKS LOADED")
+        footer.update(f" └── [{c['primary']}]{count}[/] OBJECTS LOADED")
 
     def _update_row_indicators(self, old_key: str | None, new_key: str | None) -> None:
         """Update only the indicator column for old and new selected rows.
@@ -634,9 +622,10 @@ class PhonesScreen(Screen):
         table = self.query_one("#phones-table", DataTable)
         app: PassFXApp = self.app  # type: ignore
         credentials = app.vault.get_phones()
+        c = self.COLORS
 
         # Build a map of id -> credential for quick lookup
-        cred_map = {c.id: c for c in credentials}
+        cred_map = {cred.id: cred for cred in credentials}
 
         # Get column keys (first column is the indicator)
         if not table.columns:
@@ -650,10 +639,10 @@ class PhonesScreen(Screen):
             except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
                 pass  # Row may not exist during rapid navigation
 
-        # Set new selection indicator
+        # Set new selection indicator - cyan arrow for locked target feel
         if new_key and new_key in cred_map:
             try:
-                table.update_cell(new_key, indicator_col, "[bold #8b5cf6]▍[/]")
+                table.update_cell(new_key, indicator_col, f"[bold {c['primary']}]▸[/]")
             except Exception:  # pylint: disable=broad-exception-caught  # nosec B110
                 pass  # Row may not exist during rapid navigation
 
@@ -754,18 +743,20 @@ class PhonesScreen(Screen):
         # Update only the indicator cells instead of rebuilding entire table
         self._update_row_indicators(old_key, key_value)
 
-    # pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals,too-many-statements
     def _update_inspector(self, row_key: Any) -> None:
         """Update the inspector panel with credential details.
 
-        Renders a modernized "Device Inspector" with:
-        - Digital ID Card header with 2-char avatar
-        - Block-based PIN strength progress bar
-        - Notes terminal with line numbers
-        - Footer metadata (ID, Updated)
+        Renders a structured "Device Inspector" with:
+        - Entry Header (large text, primary color)
+        - Field Grid (labels in accent, values in text)
+        - PIN Field (masked with reveal toggle hint)
+        - Strength Meter (block progress bar)
+        - Notes Section (terminal style)
         """
         inspector = self.query_one("#inspector-content", Vertical)
         inspector.remove_children()
+        c = self.COLORS
 
         # Get the credential by row key
         app: PassFXApp = self.app  # type: ignore
@@ -773,119 +764,125 @@ class PhonesScreen(Screen):
 
         # Find credential by ID
         cred = None
-        for c in credentials:
-            if c.id == str(row_key):
-                cred = c
+        for credential in credentials:
+            if credential.id == str(row_key):
+                cred = credential
                 break
 
         if not cred:
-            # Empty state
+            # Empty state - styled for Operator theme
             inspector.mount(
                 Static(
-                    "[dim #555555]╔══════════════════════════╗\n"
-                    "║    SELECT AN ENTRY       ║\n"
-                    "║    TO VIEW DETAILS       ║\n"
-                    "╚══════════════════════════╝[/]",
+                    f"[dim {c['muted']}]╔══════════════════════════════╗\n"
+                    "║                              ║\n"
+                    "║    SELECT AN ENTRY           ║\n"
+                    "║    TO INSPECT DETAILS        ║\n"
+                    "║                              ║\n"
+                    "╚══════════════════════════════╝[/]",
                     classes="inspector-empty",
                 )
             )
             return
 
         # ═══════════════════════════════════════════════════════════════
-        # SECTION 1: Digital ID Card Header with Avatar
+        # SECTION 1: Entry Header - Large title with underline
         # ═══════════════════════════════════════════════════════════════
-        initials = _get_avatar_initials(cred.label)
-        avatar_bg = _get_avatar_bg_color(cred.label)
-
-        # Build avatar box (2-line tall for visual weight)
-        avatar_top = f"[on {avatar_bg}][bold #ffffff] {initials} [/][/]"
-        avatar_bot = f"[on {avatar_bg}]     [/]"
-
         inspector.mount(
             Vertical(
-                Horizontal(
-                    Vertical(
-                        Static(avatar_top, classes="avatar-char"),
-                        Static(avatar_bot, classes="avatar-char"),
-                        classes="avatar-box",
-                    ),
-                    Vertical(
-                        Static(
-                            f"[bold #f8fafc]{cred.label}[/]",
-                            classes="id-label-text",
-                        ),
-                        Static(
-                            f"[dim #94a3b8]{cred.phone}[/]",
-                            classes="id-email-text",
-                        ),
-                        classes="id-details-stack",
-                    ),
-                    classes="id-card-header",
+                Static(
+                    f"[bold underline {c['primary']}]{cred.label.upper()}[/]",
+                    classes="inspector-title",
                 ),
-                classes="id-card-wrapper",
+                classes="inspector-header",
             )
         )
 
         # ═══════════════════════════════════════════════════════════════
-        # SECTION 2: PIN Strength Widget with Block Progress Bar
+        # SECTION 2: Field Grid - Structured label/value pairs
+        # ═══════════════════════════════════════════════════════════════
+        inspector.mount(
+            Vertical(
+                # Uplink (phone number) field
+                Horizontal(
+                    Static(f"[{c['accent']}]UPLINK[/]", classes="field-label"),
+                    Static(f"[{c['text']}]{cred.phone}[/]", classes="field-value"),
+                    classes="field-row",
+                ),
+                # PIN field - masked by default
+                Horizontal(
+                    Static(f"[{c['accent']}]ACCESS PIN[/]", classes="field-label"),
+                    Static(
+                        f"[{c['muted']}]●●●●●●[/]  " f"[dim]\\[V] to reveal[/]",
+                        classes="field-value",
+                    ),
+                    classes="field-row",
+                ),
+                classes="field-grid",
+            )
+        )
+
+        # ═══════════════════════════════════════════════════════════════
+        # SECTION 3: Strength Meter - Entropy Level Progress Bar
         # ═══════════════════════════════════════════════════════════════
         strength = check_strength(cred.password)
-        color = _get_strength_color(strength.score)
+        strength_color = _get_strength_color(strength.score)
 
-        # Build smooth block progress bar (20 chars wide)
+        # Build block progress bar (20 chars wide)
         filled_blocks = (strength.score + 1) * 4  # 0=4, 1=8, 2=12, 3=16, 4=20
         empty_blocks = 20 - filled_blocks
 
-        filled = f"[{color}]" + ("█" * filled_blocks) + "[/]"
+        filled = f"[{strength_color}]" + ("█" * filled_blocks) + "[/]"
         empty = "[#1e293b]" + ("░" * empty_blocks) + "[/]"
         progress_bar = f"{filled}{empty}"
 
-        # Strength label inline with bar
-        strength_display = f"{progress_bar} [{color}]{strength.label.upper()}[/]"
-
         inspector.mount(
             Vertical(
-                Static("[dim #6b7280]▸ PIN ANALYSIS[/]", classes="section-label"),
-                Static(strength_display, classes="strength-bar-widget"),
                 Static(
-                    f"[dim #475569]Complexity:[/] [#94a3b8]{strength.crack_time}[/]",
-                    classes="crack-time-label",
+                    f"[{c['accent']}]ENTROPY LEVEL[/]", classes="strength-section-label"
                 ),
-                classes="security-widget",
+                Static(progress_bar, classes="strength-bar"),
+                Static(
+                    f"[{strength_color}]{strength.label.upper()}[/]  "
+                    f"[dim {c['muted']}]// {strength.crack_time}[/]",
+                    classes="strength-label",
+                ),
+                classes="strength-section",
             )
         )
 
         # ═══════════════════════════════════════════════════════════════
-        # SECTION 3: Notes Terminal with Line Numbers
+        # SECTION 4: Notes Terminal - Styled like terminal output
         # ═══════════════════════════════════════════════════════════════
         if cred.notes:
-            # Split notes into lines and add line numbers
             lines = cred.notes.split("\n")
             numbered_lines = []
-            for i, line in enumerate(lines[:10], 1):  # Limit to 10 lines
-                line_num = f"[dim #475569]{i:2}[/]"
-                line_content = f"[#d946ef]{line}[/]" if line.strip() else ""
+            for i, line in enumerate(lines[:8], 1):  # Limit to 8 lines
+                line_num = f"[dim {c['muted']}]{i:2}[/]"
+                line_content = f"[{c['success']}]{line}[/]" if line.strip() else ""
                 numbered_lines.append(f"{line_num} │ {line_content}")
             notes_content = "\n".join(numbered_lines)
         else:
-            notes_content = "[dim #475569] 1[/] │ [dim #64748b]// NO NOTES[/]"
+            notes_content = (
+                f"[dim {c['muted']}] 1[/] │ [dim {c['muted']}]// NO NOTES[/] "
+            )
 
         notes_terminal = Vertical(
             Static(notes_content, classes="notes-code"),
-            classes="notes-editor",
+            Static("▌", classes="blink-cursor") if not cred.notes else Static(""),
+            classes="notes-terminal-box",
         )
-        notes_terminal.border_title = "ENCRYPTED_NOTES"
+        notes_terminal.border_title = "NOTES"
 
         inspector.mount(
             Vertical(
-                Static("[dim #6b7280]▸ METADATA[/]", classes="section-label"),
+                Static(f"[{c['accent']}]METADATA[/]", classes="notes-section-label"),
                 notes_terminal,
                 classes="notes-section",
             )
         )
 
         # ═══════════════════════════════════════════════════════════════
-        # SECTION 4: Footer Metadata Bar (ID + Updated)
+        # SECTION 5: Footer Metadata Bar (ID + Updated)
         # ═══════════════════════════════════════════════════════════════
         try:
             updated_full = datetime.fromisoformat(cred.updated_at).strftime(
@@ -897,11 +894,11 @@ class PhonesScreen(Screen):
         inspector.mount(
             Horizontal(
                 Static(
-                    f"[dim #475569]ID:[/] [#64748b]{cred.id[:8]}[/]",
+                    f"[dim {c['muted']}]ID:[/] [{c['muted']}]{cred.id[:8]}[/]",
                     classes="meta-id",
                 ),
                 Static(
-                    f"[dim #475569]UPDATED:[/] [#64748b]{updated_full}[/]",
+                    f"[dim {c['muted']}]SYNC:[/] [{c['muted']}]{updated_full}[/]",
                     classes="meta-updated",
                 ),
                 classes="inspector-footer-bar",

--- a/passfx/styles/passfx.tcss
+++ b/passfx/styles/passfx.tcss
@@ -30,6 +30,7 @@ $surface-black: #0a0a0a;
 $operator-black: #000000;
 $operator-primary: #00FFFF;
 $operator-secondary: #8b5cf6;
+$operator-pink: #ec4899;
 $operator-surface: #0a0a0a;
 $operator-text: #e0e0e0;
 $operator-muted: #666666;
@@ -1106,14 +1107,13 @@ PasswordsScreen .screen-header {
 }
 
 /* Pink variant for phones screen */
-.pane-header-block-purple {
+.pane-header-block-pink {
     width: 100%;
     height: 1;
-    background: #d946ef;
+    background: $operator-pink;
     color: #000000;
     text-style: bold;
     padding: 0 1;
-    margin-bottom: 0;
 }
 
 /* Green variant for cards screen - lime green for contrast */
@@ -1262,6 +1262,89 @@ PasswordsScreen .keycap-label {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
+   PHONES SCREEN - OPERATOR THEME DATA CONSOLE (Pink Accent)
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* Screen-level background - pure black Operator theme */
+PhonesScreen {
+    background: $operator-black;
+    padding: 0;
+    margin: 0;
+    border: none;
+}
+
+/* Force background on all direct children */
+PhonesScreen #app-header,
+PhonesScreen #vault-body,
+PhonesScreen #app-footer {
+    background: $operator-black;
+}
+
+/* Header for phones screen */
+PhonesScreen #app-header {
+    background: $operator-black;
+    border-bottom: heavy $operator-primary;
+}
+
+PhonesScreen #header-branding {
+    color: $operator-primary;
+    text-style: bold;
+}
+
+PhonesScreen .screen-header {
+    text-style: bold;
+}
+
+/* Phones screen specific footer */
+PhonesScreen .pane-footer {
+    background: $operator-black;
+    color: $operator-muted;
+    border-top: solid $operator-pink 30%;
+}
+
+/* Phones screen app footer - Operator theme with pink accent */
+PhonesScreen #app-footer {
+    width: 100%;
+    height: 3;
+    dock: bottom;
+    background: $operator-black;
+    border-top: heavy $operator-pink;
+    align: left middle;
+    padding: 0;
+    margin: 0;
+}
+
+PhonesScreen #footer-version {
+    background: $operator-black;
+    color: $operator-muted;
+    width: auto;
+    height: 3;
+    padding: 0 2;
+    content-align: center middle;
+}
+
+PhonesScreen #footer-keys {
+    background: $operator-black;
+    width: 1fr;
+    height: 3;
+    align: left middle;
+    padding-left: 1;
+}
+
+PhonesScreen .keycap-group {
+    background: $operator-black;
+    height: auto;
+}
+
+PhonesScreen .keycap {
+    background: $operator-surface;
+}
+
+PhonesScreen .keycap-label {
+    background: $operator-black;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
    PASSWORDS TABLE - OPERATOR THEME DATA STREAM
    ═══════════════════════════════════════════════════════════════════════════ */
 
@@ -1313,11 +1396,12 @@ PasswordsScreen .keycap-label {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
-   PHONES TABLE - MAINFRAME TERMINAL LOOK (matches passwords-table)
+   PHONES TABLE - OPERATOR THEME DATA STREAM (Pink Accent)
    ═══════════════════════════════════════════════════════════════════════════ */
 
+/* Phones Table - Pure black data stream terminal */
 #phones-table {
-    background: $pfx-bg;
+    background: $operator-black;
     border: none;
     margin: 0;
     padding: 0;
@@ -1330,31 +1414,36 @@ PasswordsScreen .keycap-label {
     border: none;
 }
 
+/* Data stream selection - locked target feel with left border */
 #phones-table > .datatable--cursor {
-    background: #2d1f4a;
+    background: #1a0a12;
     color: $pfx-fg;
-    text-style: none;
+    text-style: bold;
+    border-left: heavy $operator-pink;
 }
 
 #phones-table > .datatable--cursor:hover {
-    background: #3b2d5a;
+    background: #1a0a12;
 }
 
+/* Headers - Pink accent for system labels */
 #phones-table > .datatable--header {
-    background: #8b5cf6;
-    color: black;
+    background: $operator-pink;
+    color: #000000;
     text-style: bold;
-    border-right: solid #8b5cf6;
 }
 
+/* Row styling - dark data stream with subtle separators and breathing room */
 #phones-table > .datatable--even-row {
-    background: #02040a;
-    border-bottom: solid #1e293b;
+    background: $operator-black;
+    border-bottom: solid #1a1a1a;
+    height: 2;
 }
 
 #phones-table > .datatable--odd-row {
-    background: #060a12;
-    border-bottom: solid #1e293b;
+    background: #050505;
+    border-bottom: solid #1a1a1a;
+    height: 2;
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Bring Phones vault page to visual parity with Passwords vault page using a Pink accent theme (#ec4899) instead of Purple. This ensures consistent Operator Console aesthetics across credential screens while maintaining distinct color identity for data classes.

## Motivation

The Phones screen had significant styling gaps compared to the Passwords screen:
- Used legacy `$pfx-bg` instead of `$operator-black`
- Missing cursor left border for selection feedback
- Used emoji status icons instead of bullet indicators
- Lacked mechanical keycap footer styling
- Inspector used avatar card pattern instead of field grid

This PR brings full visual parity: "Same Operator Console — different data class."

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure / CI / tooling
- [ ] Refactoring (no functional changes)

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] N/A (documentation only)

## Risk Assessment

**Risk level:** Low

**Areas affected:**
- `passfx/screens/phones.py` - Phones vault screen UI
- `passfx/styles/passfx.tcss` - TCSS styling additions

## Security Considerations

- [ ] No credentials or secrets exposed
- [ ] Sensitive data properly cleared from memory
- [ ] File permissions verified (0600/0700)
- [x] N/A (no security-sensitive changes)

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format