### PR TITLE
feat(ui): refactor Cards screen to Operator cyberpunk aesthetic

### DIFF
--- a/passfx/styles/passfx.tcss
+++ b/passfx/styles/passfx.tcss
@@ -1116,11 +1116,11 @@ PasswordsScreen .screen-header {
     padding: 0 1;
 }
 
-/* Green variant for cards screen - lime green for contrast */
+/* Green variant for cards screen - financial green (same luminosity as purple) */
 .pane-header-block-green {
     width: 100%;
     height: 1;
-    background: #84cc16;
+    background: #22c55e;
     color: #000000;
     text-style: bold;
     padding: 0 1;
@@ -1345,6 +1345,107 @@ PhonesScreen .keycap-label {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
+   CARDS SCREEN - OPERATOR THEME WITH GREEN ACCENT
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* Force background on all direct children */
+CardsScreen #app-header,
+CardsScreen #vault-body,
+CardsScreen #app-footer {
+    background: $operator-black;
+}
+
+/* Header for cards screen - cyan underline */
+CardsScreen #app-header {
+    background: $operator-black;
+    border-bottom: heavy $operator-primary;
+}
+
+CardsScreen #header-right {
+    background: $operator-black;
+    color: $operator-muted;
+    width: 1fr;
+    height: 100%;
+    align: right middle;
+    padding-right: 2;
+}
+
+/* Pane footer for cards screen */
+CardsScreen .pane-footer {
+    background: $operator-black;
+    color: $operator-muted;
+    border-top: solid #22c55e 30%;
+}
+
+/* Cards screen app footer - Operator theme with green accent */
+CardsScreen #app-footer {
+    width: 100%;
+    height: 3;
+    dock: bottom;
+    background: $operator-black;
+    border-top: heavy #22c55e;
+    align: left middle;
+    padding: 0;
+    margin: 0;
+}
+
+CardsScreen #footer-version {
+    background: $operator-black;
+    color: $operator-muted;
+    width: auto;
+    height: 3;
+    padding: 0 2;
+    content-align: center middle;
+}
+
+CardsScreen #footer-keys {
+    background: $operator-black;
+    width: 1fr;
+    height: 3;
+    align: left middle;
+    padding-left: 1;
+}
+
+CardsScreen .keycap-group {
+    background: $operator-black;
+    height: auto;
+}
+
+CardsScreen .keycap {
+    background: $operator-surface;
+}
+
+CardsScreen .keycap-label {
+    background: $operator-black;
+}
+
+/* Cards modals - wider to prevent scrolling */
+CardsScreen #pwd-modal.secure-terminal {
+    width: 80;
+    max-height: 90%;
+}
+
+/* Horizontal input row for side-by-side fields */
+CardsScreen .input-row {
+    width: 100%;
+    height: auto;
+    align: left top;
+}
+
+/* Standard column - takes half width */
+CardsScreen .input-col {
+    width: 1fr;
+    height: auto;
+    padding-right: 1;
+}
+
+/* Small column for CVV - fixed width */
+CardsScreen .input-col-small {
+    width: 20;
+    height: auto;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
    PASSWORDS TABLE - OPERATOR THEME DATA STREAM
    ═══════════════════════════════════════════════════════════════════════════ */
 
@@ -1447,11 +1548,12 @@ PhonesScreen .keycap-label {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
-   CARDS TABLE - MAINFRAME TERMINAL LOOK (matches passwords-table)
+   CARDS TABLE - FINANCIAL VAULT (matches passwords-table structure)
+   Green accent theme (#22c55e) - same luminosity as purple accent
    ═══════════════════════════════════════════════════════════════════════════ */
 
 #cards-table {
-    background: $pfx-bg;
+    background: $operator-black;
     border: none;
     margin: 0;
     padding: 0;
@@ -1464,30 +1566,36 @@ PhonesScreen .keycap-label {
     border: none;
 }
 
+/* Data stream selection - locked target feel with left border */
 #cards-table > .datatable--cursor {
-    background: #064e3b;
+    background: #0a1a1a;
     color: $pfx-fg;
-    text-style: none;
+    text-style: bold;
+    border-left: heavy $operator-primary;
 }
 
 #cards-table > .datatable--cursor:hover {
-    background: #065f46;
+    background: #0a1a1a;
 }
 
+/* Headers - Green accent for Financial Vault */
 #cards-table > .datatable--header {
-    background: #10b981;
-    color: black;
+    background: #22c55e;
+    color: #000000;
     text-style: bold;
 }
 
+/* Row styling - dark data stream with subtle separators and breathing room */
 #cards-table > .datatable--even-row {
-    background: #02040a;
-    border-bottom: solid #1e293b;
+    background: $operator-black;
+    border-bottom: solid #1a1a1a;
+    height: 2;
 }
 
 #cards-table > .datatable--odd-row {
-    background: #060a12;
-    border-bottom: solid #1e293b;
+    background: #050505;
+    border-bottom: solid #1a1a1a;
+    height: 2;
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Bring Cards Vault page to visual and structural parity with Passwords screen using Green accent theme (#22c55e) for financial asset class. This ensures design system consistency across all vault screens.

## Motivation

The Cards screen needed visual alignment with the recently refactored Passwords and Phones screens to maintain the Operator Console aesthetic throughout the app.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure / CI / tooling
- [x] Refactoring (no functional changes)

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] N/A (documentation only)

## Risk Assessment

**Risk level:** Low

**Areas affected:**
- Cards screen UI (`passfx/screens/cards.py`)
- TCSS styles (`passfx/styles/passfx.tcss`)

## Security Considerations

- [x] No credentials or secrets exposed
- [x] Sensitive data properly cleared from memory
- [x] File permissions verified (0600/0700)
- [x] N/A (no security-sensitive changes)

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format

## Changes

### Python (`cards.py`)
- Add `COLORS` dict with green accent for consistent theming
- Update row indicator from `▍` to `▸` matching Passwords pattern
- Redesign inspector panel with field grid structure (Entry Header → Field Grid → Notes → Footer)
- Add `_is_expiry_near()` helper for expiry warning (≤60 days shows amber)
- Add `_blink_cursor()` method for empty notes animation
- Update pulse animation to use COLORS dict
- Redesign Add/Edit/View modals with horizontal layout:
  - Issuer + Cardholder on same row
  - Expiry + CVV on same row
  - Prevents overflow/scrolling in terminal

### TCSS (`passfx.tcss`)
- Add CardsScreen-specific styles section
- Header: cyan underline (`border-bottom: heavy $operator-primary`)
- Footer: green accent line (`border-top: heavy #22c55e`)
- Table headers: financial green (#22c55e) background
- Active row: cyan left border matching Passwords
- Keycap styling for footer shortcuts
- Modal horizontal layout classes (`.input-row`, `.input-col`, `.input-col-small`)
- Update `.pane-header-block-green` from lime to financial green