### PR TITLE
feat(ui): implement unified accent color system across all screens

### DIFF
--- a/passfx/screens/cards.py
+++ b/passfx/screens/cards.py
@@ -701,7 +701,7 @@ class CardsScreen(Screen):
         # 1. Global Header - Operator theme
         with Horizontal(id="app-header"):
             yield Static(
-                f"[bold {c['primary']}]VAULT // CARDS[/]",
+                f"[bold {c['accent']}]VAULT // CARDS[/]",
                 id="header-branding",
                 classes="screen-header",
             )

--- a/passfx/screens/envs.py
+++ b/passfx/screens/envs.py
@@ -556,7 +556,7 @@ class EnvsScreen(Screen):
         # 1. Global Header with Breadcrumbs - Operator theme
         with Horizontal(id="app-header"):
             yield Static(
-                f"[bold {c['primary']}]VAULT // CONFIG_FILES[/]",
+                f"[bold {c['accent']}]VAULT // CONFIG_FILES[/]",
                 id="header-branding",
                 classes="screen-header",
             )

--- a/passfx/screens/notes.py
+++ b/passfx/screens/notes.py
@@ -383,7 +383,7 @@ class NotesScreen(Screen):
         # 1. Global Header with Breadcrumbs - Operator theme
         with Horizontal(id="app-header"):
             yield Static(
-                f"[bold {c['primary']}]VAULT // DATA_SHARDS[/]",
+                f"[bold {c['accent']}]VAULT // DATA_SHARDS[/]",
                 id="header-branding",
                 classes="screen-header",
             )

--- a/passfx/screens/passwords.py
+++ b/passfx/screens/passwords.py
@@ -494,7 +494,7 @@ class PasswordsScreen(Screen):
         # 1. Global Header with Breadcrumbs - Operator theme
         with Horizontal(id="app-header"):
             yield Static(
-                f"[bold {c['primary']}]VAULT // DATABASE[/]",
+                f"[bold {c['accent']}]VAULT // DATABASE[/]",
                 id="header-branding",
                 classes="screen-header",
             )

--- a/passfx/screens/phones.py
+++ b/passfx/screens/phones.py
@@ -439,7 +439,7 @@ class PhonesScreen(Screen):
         # 1. Global Header with Breadcrumbs - Operator theme
         with Horizontal(id="app-header"):
             yield Static(
-                f"[bold {c['primary']}]VAULT // COMMS[/]",
+                f"[bold {c['accent']}]VAULT // COMMS[/]",
                 id="header-branding",
                 classes="screen-header",
             )

--- a/passfx/styles/passfx.tcss
+++ b/passfx/styles/passfx.tcss
@@ -65,7 +65,7 @@ MainMenuScreen {
     height: 4;
     dock: top;
     background: $operator-black;
-    border-bottom: heavy $operator-secondary;
+    border-bottom: heavy $operator-primary;
     align: left middle;
 }
 
@@ -141,7 +141,7 @@ FooterKey > .footer-key--description {
     height: 3;
     dock: bottom;
     background: $operator-black;
-    border-top: heavy $operator-secondary;
+    border-top: heavy $operator-primary;
     align: center middle;
     padding: 0;
     margin: 0;
@@ -452,30 +452,29 @@ LoginScreen {
     background: transparent;
 }
 
-/* Distinct neon colors for each stat category - Row 1 */
+/* Digit colors match each screen's accent color */
 #digits-passwords {
-    color: $pfx-primary-light;
+    color: #8b5cf6;  /* Purple - matches PasswordsScreen */
 }
 
 #digits-phones {
-    color: $pfx-accent;
+    color: #ec4899;  /* Pink - matches PhonesScreen */
 }
 
 #digits-cards {
-    color: $pfx-success;
+    color: #22c55e;  /* Green - matches CardsScreen */
 }
 
-/* Distinct neon colors for each stat category - Row 2 */
 #digits-notes {
-    color: #fbbf24;
+    color: #fde047;  /* Amber - matches NotesScreen */
 }
 
 #digits-envs {
-    color: #a5b4fc;
+    color: #818cf8;  /* Indigo - matches EnvsScreen */
 }
 
 #digits-recovery {
-    color: #fb7185;
+    color: #ff6f6f;  /* Salmon - matches RecoveryScreen */
 }
 
 /* Panels Row - Responsive Side-by-Side Layout */
@@ -1040,10 +1039,10 @@ PasswordsScreen #app-footer {
     background: $operator-black;
 }
 
-/* Header for vault screen */
+/* Header for vault screen - purple accent */
 PasswordsScreen #app-header {
     background: $operator-black;
-    border-bottom: heavy $operator-primary;
+    border-bottom: heavy $operator-secondary;
 }
 
 PasswordsScreen #header-branding {
@@ -1149,11 +1148,11 @@ PasswordsScreen .screen-header {
     margin-bottom: 0;
 }
 
-/* Rose variant for recovery screen - lighter salmon pink for contrast */
-.pane-header-block-rose {
+/* Salmon variant for recovery screen - controlled accent for fail-safe protocol */
+.pane-header-block-salmon {
     width: 100%;
     height: 1;
-    background: #fda4af;
+    background: #ff6f6f;
     color: #000000;
     text-style: bold;
     padding: 0 1;
@@ -1180,11 +1179,51 @@ PasswordsScreen .screen-header {
     dock: bottom;
 }
 
-/* Passwords screen specific footer */
+/* Passwords screen specific footer - purple accent */
 PasswordsScreen .pane-footer {
     background: $operator-black;
     color: $operator-muted;
-    border-top: solid $operator-primary 30%;
+    border-top: solid $operator-secondary 30%;
+}
+
+/* Passwords screen inspector header - purple accent */
+PasswordsScreen .pane-header-block-accent {
+    width: 100%;
+    height: 1;
+    background: $operator-secondary;
+    color: #000000;
+    text-style: bold;
+    padding: 0 1;
+}
+
+/* Passwords screen terminal box - purple border */
+PasswordsScreen .notes-terminal-box {
+    background: #050505;
+    border: solid $operator-secondary 50%;
+    width: 100%;
+    height: 1fr;
+    min-height: 5;
+    padding: 1;
+    overflow-y: auto;
+    border-title-align: center;
+    border-title-color: $operator-secondary;
+}
+
+/* Passwords screen inspector header underline */
+PasswordsScreen .inspector-header {
+    width: 100%;
+    height: auto;
+    padding: 1 0;
+    margin-bottom: 1;
+    border-bottom: solid $operator-secondary 30%;
+}
+
+/* Passwords screen vault grid pane - purple border */
+PasswordsScreen #vault-grid-pane {
+    width: 65%;
+    height: 100%;
+    background: $operator-black;
+    border-right: solid $operator-secondary 30%;
 }
 
 /* Empty State - Centered message when no credentials exist */
@@ -1280,10 +1319,10 @@ PhonesScreen #app-footer {
     background: $operator-black;
 }
 
-/* Header for phones screen */
+/* Header for phones screen - pink accent */
 PhonesScreen #app-header {
     background: $operator-black;
-    border-bottom: heavy $operator-primary;
+    border-bottom: heavy $operator-pink;
 }
 
 PhonesScreen #header-branding {
@@ -1295,11 +1334,51 @@ PhonesScreen .screen-header {
     text-style: bold;
 }
 
-/* Phones screen specific footer */
+/* Phones screen specific footer - pink accent */
 PhonesScreen .pane-footer {
     background: $operator-black;
     color: $operator-muted;
     border-top: solid $operator-pink 30%;
+}
+
+/* Phones screen inspector header - pink accent */
+PhonesScreen .pane-header-block-accent {
+    width: 100%;
+    height: 1;
+    background: $operator-pink;
+    color: #000000;
+    text-style: bold;
+    padding: 0 1;
+}
+
+/* Phones screen terminal box - pink border */
+PhonesScreen .notes-terminal-box {
+    background: #050505;
+    border: solid $operator-pink 50%;
+    width: 100%;
+    height: 1fr;
+    min-height: 5;
+    padding: 1;
+    overflow-y: auto;
+    border-title-align: center;
+    border-title-color: $operator-pink;
+}
+
+/* Phones screen inspector header underline */
+PhonesScreen .inspector-header {
+    width: 100%;
+    height: auto;
+    padding: 1 0;
+    margin-bottom: 1;
+    border-bottom: solid $operator-pink 30%;
+}
+
+/* Phones screen vault grid pane - pink border */
+PhonesScreen #vault-grid-pane {
+    width: 65%;
+    height: 100%;
+    background: $operator-black;
+    border-right: solid $operator-pink 30%;
 }
 
 /* Phones screen app footer - Operator theme with pink accent */
@@ -1355,10 +1434,10 @@ CardsScreen #app-footer {
     background: $operator-black;
 }
 
-/* Header for cards screen - cyan underline */
+/* Header for cards screen - green accent */
 CardsScreen #app-header {
     background: $operator-black;
-    border-bottom: heavy $operator-primary;
+    border-bottom: heavy #22c55e;
 }
 
 CardsScreen #header-right {
@@ -1370,11 +1449,51 @@ CardsScreen #header-right {
     padding-right: 2;
 }
 
-/* Pane footer for cards screen */
+/* Pane footer for cards screen - green accent */
 CardsScreen .pane-footer {
     background: $operator-black;
     color: $operator-muted;
     border-top: solid #22c55e 30%;
+}
+
+/* Cards screen inspector header - green accent */
+CardsScreen .pane-header-block-accent {
+    width: 100%;
+    height: 1;
+    background: #22c55e;
+    color: #000000;
+    text-style: bold;
+    padding: 0 1;
+}
+
+/* Cards screen terminal box - green border */
+CardsScreen .notes-terminal-box {
+    background: #050505;
+    border: solid #22c55e 50%;
+    width: 100%;
+    height: 1fr;
+    min-height: 5;
+    padding: 1;
+    overflow-y: auto;
+    border-title-align: center;
+    border-title-color: #22c55e;
+}
+
+/* Cards screen inspector header underline */
+CardsScreen .inspector-header {
+    width: 100%;
+    height: auto;
+    padding: 1 0;
+    margin-bottom: 1;
+    border-bottom: solid #22c55e 30%;
+}
+
+/* Cards screen vault grid pane - green border */
+CardsScreen #vault-grid-pane {
+    width: 65%;
+    height: 100%;
+    background: $operator-black;
+    border-right: solid #22c55e 30%;
 }
 
 /* Cards screen app footer - Operator theme with green accent */
@@ -1468,10 +1587,10 @@ NotesScreen #app-footer {
     background: $operator-black;
 }
 
-/* Header for notes screen - cyan underline */
+/* Header for notes screen - amber accent */
 NotesScreen #app-header {
     background: $operator-black;
-    border-bottom: heavy $operator-primary;
+    border-bottom: heavy #fde047;
 }
 
 NotesScreen #header-branding {
@@ -3542,35 +3661,151 @@ Button.env-delete-btn:focus {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════════
-   RECOVERY CODES SCREEN - FAIL-SAFE PROTOCOL THEME
-   Theme: Rose/Red (#f43f5e) for Emergency Use Only
+   RECOVERY CODES SCREEN - FAIL-SAFE PROTOCOL THEME (Salmon Accent)
+   Operator Theme Parity: Matches ENV VAR screen structure exactly
    ═══════════════════════════════════════════════════════════════════════════════ */
 
-/* Rose accent color */
-$pfx-rose: #f43f5e;
-$pfx-rose-dim: #881337;
-$pfx-rose-light: #fb7185;
+/* Salmon accent color for Recovery (Fail-Safe Protocol) */
+$pfx-salmon: #ff6f6f;
+$pfx-salmon-dim: #cc5959;
+$pfx-salmon-dark: #993f3f;
 
-/* Recovery Header Block - Rose variant */
-.recovery-header {
-    background: #f43f5e;
+/* Screen background - pure black operator theme */
+RecoveryScreen {
+    background: $operator-black;
+}
+
+RecoveryScreen #app-header {
+    background: $operator-black;
+    border-bottom: heavy $pfx-salmon-dim;
+}
+
+RecoveryScreen #header-branding {
+    background: $operator-black;
+}
+
+RecoveryScreen #app-footer {
+    background: $operator-black;
+    border-top: heavy $pfx-salmon-dim;
+}
+
+RecoveryScreen #footer-version {
+    background: $operator-black;
+}
+
+RecoveryScreen #footer-keys {
+    background: $operator-black;
+}
+
+RecoveryScreen .keycap {
+    background: $operator-surface;
+}
+
+RecoveryScreen .keycap-label {
+    background: $operator-black;
+}
+
+/* Recovery screen inspector header - salmon accent */
+RecoveryScreen .pane-header-block-accent {
+    width: 100%;
+    height: 1;
+    background: $pfx-salmon;
     color: #000000;
+    text-style: bold;
+    padding: 0 1;
 }
 
-/* Recovery Card wrapper with rose accent */
-.recovery-card {
-    border-left: heavy #f43f5e;
+/* Recovery screen inspector content - full width */
+RecoveryScreen #inspector-content {
+    width: 100%;
+    height: 1fr;
+    padding: 1 2;
+    overflow-y: auto;
+    background: $operator-black;
 }
 
-/* Recovery Preview with rose border */
-.recovery-preview {
-    border: solid #f43f5e 50%;
-    border-title-color: #f43f5e;
+/* Recovery screen terminal box - salmon border title */
+RecoveryScreen .notes-terminal-box {
+    background: #050505;
+    border: solid $pfx-salmon 50%;
+    width: 100%;
+    height: 1fr;
+    min-height: 5;
+    padding: 1;
+    overflow-y: auto;
+    border-title-align: center;
+    border-title-color: $pfx-salmon;
 }
 
-/* Recovery Table - Mainframe Terminal Look with Rose accents */
-#recovery-table {
-    background: $pfx-bg;
+/* Recovery screen sections fill width */
+RecoveryScreen .notes-section {
+    width: 100%;
+    height: 1fr;
+}
+
+RecoveryScreen .strength-section {
+    width: 100%;
+    height: auto;
+    padding: 0 0 1 0;
+    margin-bottom: 1;
+}
+
+RecoveryScreen .field-grid {
+    width: 100%;
+    height: auto;
+    padding: 0 0 1 0;
+}
+
+RecoveryScreen .inspector-header {
+    width: 100%;
+    height: auto;
+    padding: 1 0;
+    margin-bottom: 1;
+    border-bottom: solid $pfx-salmon 30%;
+}
+
+/* Recovery screen vault panes - ensure full fill */
+RecoveryScreen #vault-body {
+    width: 100%;
+    height: 100%;
+    background: $operator-black;
+}
+
+RecoveryScreen #vault-grid-pane {
+    width: 65%;
+    height: 100%;
+    background: $operator-black;
+    border-right: solid $pfx-salmon 30%;
+}
+
+RecoveryScreen #vault-inspector {
+    width: 35%;
+    height: 100%;
+    background: $operator-black;
+    padding: 0;
+    overflow-y: hidden;
+}
+
+/* Ensure all inspector children fill width */
+RecoveryScreen #inspector-content > Vertical {
+    width: 100%;
+}
+
+RecoveryScreen #inspector-content > Vertical > Horizontal {
+    width: 100%;
+}
+
+RecoveryScreen #inspector-content > Vertical > Vertical {
+    width: 100%;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════════
+   RECOVERY TABLE - OPERATOR THEME DATA STREAM (Salmon Accent)
+   ═══════════════════════════════════════════════════════════════════════════════ */
+
+/* Recovery Table - Pure black data stream terminal */
+RecoveryScreen #recovery-table {
+    background: $operator-black;
     border: none;
     margin: 0;
     padding: 0;
@@ -3579,366 +3814,108 @@ $pfx-rose-light: #fb7185;
     overflow-x: hidden;
 }
 
-#recovery-table:focus {
+RecoveryScreen #recovery-table:focus {
     border: none;
 }
 
-#recovery-table > .datatable--cursor {
-    background: #9f1239;
+/* Data stream selection - prominent salmon highlight with cyan border */
+RecoveryScreen #recovery-table > .datatable--cursor {
+    background: #993f3f;
     color: $pfx-fg;
-    text-style: none;
+    text-style: bold;
+    border-left: heavy $operator-primary;
 }
 
-#recovery-table > .datatable--cursor:hover {
-    background: #be123c;
+RecoveryScreen #recovery-table > .datatable--cursor:hover {
+    background: #b34d4d;
 }
 
-#recovery-table > .datatable--header {
-    background: #f43f5e;
-    color: black;
+/* Headers - Salmon accent for fail-safe labels */
+RecoveryScreen #recovery-table > .datatable--header {
+    background: $pfx-salmon;
+    color: #000000;
     text-style: bold;
 }
 
-#recovery-table > .datatable--even-row {
-    background: #02040a;
-    border-bottom: solid #1e293b;
-}
-
-#recovery-table > .datatable--odd-row {
-    background: #060a12;
-    border-bottom: solid #1e293b;
-}
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   RECOVERY CODE EDITOR / TEXTAREA STYLING
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
-/* Code Editor TextArea - Dark terminal look with Rose accent */
-.recovery-code-editor {
-    background: #1e1e1e;
-    color: #d4d4d4;
-    border: solid #f43f5e 50%;
-    padding: 1;
-    margin: 0 0 1 0;
-    height: 12;
-    max-height: 12;
-}
-
-.recovery-code-editor:focus {
-    border: solid #f43f5e;
-}
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   RECOVERY MODAL SCREENS
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
-/* View Recovery Modal */
-#recovery-view-modal {
-    width: 70;
-    height: auto;
-    max-height: 40;
-    background: $pfx-bg;
-    border: heavy #f43f5e;
-    padding: 1 2;
-}
-
-#recovery-view-title {
-    text-align: center;
-    text-style: bold;
-    color: #f43f5e;
-    padding: 0 0 1 0;
-    border-bottom: solid #f43f5e 50%;
-}
-
-#recovery-view-info {
-    padding: 1 0;
-}
-
-.recovery-view-name {
-    text-style: bold;
-}
-
-.recovery-view-stats {
-    height: auto;
-}
-
-.recovery-view-stats Static {
-    margin-right: 3;
-}
-
-/* Read-only code editor for viewing - Rose theme */
-.recovery-code-editor-view {
-    background: #1e1e1e;
-    color: #d4d4d4;
-    border: solid #f43f5e 50%;
-    padding: 1;
-    height: 16;
-    max-height: 16;
-}
-
-#recovery-view-footer {
-    text-align: center;
-    padding: 1 0;
-}
-
-#recovery-view-modal #modal-buttons {
-    width: 100%;
-    height: auto;
-    padding: 1 0 0 0;
-    align: center middle;
-}
-
-#recovery-view-modal #modal-buttons Button {
-    width: 16;
-    margin: 0 2;
-}
-
-/* Add/Edit Recovery Modal */
-#recovery-edit-modal {
-    width: 70;
-    height: auto;
-    max-height: 45;
-    background: $pfx-bg;
-    border: heavy #f43f5e;
-    padding: 2 3;
-}
-
-#recovery-edit-title {
-    text-style: bold;
-    color: #f43f5e;
-    text-align: center;
-    padding: 0 0 1 0;
-    margin-bottom: 1;
-}
-
-#recovery-form {
-    padding: 1 0;
-    height: auto;
-    max-height: 35;
-    overflow-y: auto;
-}
-
-.recovery-input-label {
-    color: #f43f5e;
-    text-style: bold;
-    padding: 1 0 0 0;
-    margin: 0;
-}
-
-#recovery-form Input {
-    background: transparent;
-    border: none;
-    border-bottom: solid #881337;
-    padding: 0 1 0 1;
-    margin: 0 0 1 0;
-    color: $pfx-fg;
-    width: 100%;
+/* Row styling - dark data stream with subtle separators and breathing room */
+RecoveryScreen #recovery-table > .datatable--even-row {
+    background: $operator-black;
+    border-bottom: solid #1a1a1a;
     height: 2;
 }
 
-#recovery-form Input:focus {
-    border-bottom: heavy #f43f5e;
+RecoveryScreen #recovery-table > .datatable--odd-row {
+    background: #050505;
+    border-bottom: solid #1a1a1a;
+    height: 2;
 }
 
-/* Recovery Modal Buttons Container */
-#recovery-edit-modal #modal-buttons {
+/* Recovery screen pane footer */
+RecoveryScreen .pane-footer {
+    background: $operator-black;
+    color: $operator-muted;
+    border-top: solid $pfx-salmon 30%;
+}
+
+/* Recovery modals - landscape layout to prevent scrolling */
+#pwd-modal.recovery-modal-wide {
+    width: 100;
+    max-height: 85%;
+}
+
+/* Recovery modal buttons */
+.recovery-modal-wide #modal-buttons {
     width: 100%;
     height: auto;
-    padding: 2 0 0 0;
     align: center middle;
-}
-
-#recovery-edit-modal #modal-buttons Button {
-    width: 16;
-    margin: 0 1;
-}
-
-#recovery-edit-modal #cancel-button {
-    background: $pfx-surface;
-    color: $pfx-muted;
-    border: solid $pfx-surface-light;
-}
-
-#recovery-edit-modal #cancel-button:hover {
-    background: $pfx-surface-light;
-    color: $pfx-fg;
-}
-
-/* Import button - Rose distinctive style */
-Button.recovery-import-btn {
-    background: #4c0519;
-    color: #fb7185;
-    border: solid #f43f5e;
-    text-style: bold;
     content-align: center middle;
+    padding: 1 0 0 0;
 }
 
-Button.recovery-import-btn:hover {
-    background: #f43f5e;
-    color: #000000;
-}
-
-Button.recovery-import-btn:focus {
-    background: #881337;
-    color: #fb7185;
-    border: solid #f43f5e;
-}
-
-/* Recovery Modal Save Button - Rose styling */
-Button.recovery-save-btn {
-    background: #f43f5e;
-    color: #000000;
-    border: solid #f43f5e;
-    text-style: bold;
-    content-align: center middle;
-}
-
-Button.recovery-save-btn:hover {
-    background: #fb7185;
-    color: #000000;
-}
-
-Button.recovery-save-btn:focus {
-    background: #fb7185;
-    color: #000000;
-    border: solid #fb7185;
-}
-
-/* Recovery Modal Delete Button - Red styling */
-Button.recovery-delete-btn {
-    background: #ef4444;
-    color: #ffffff;
-    border: solid #ef4444;
-    text-style: bold;
-    content-align: center middle;
-}
-
-Button.recovery-delete-btn:hover {
-    background: #dc2626;
-    color: #ffffff;
-}
-
-Button.recovery-delete-btn:focus {
-    background: #dc2626;
-    color: #ffffff;
-    border: solid #dc2626;
-}
-
-/* Import Path Modal - Rose theme */
-#recovery-import-modal {
-    width: 50;
-    height: auto;
-    background: $pfx-bg;
-    border: heavy #f43f5e;
-    padding: 2 3;
-}
-
-#recovery-import-title {
-    text-style: bold;
-    color: #f43f5e;
-    text-align: center;
-    padding: 0 0 1 0;
-}
-
-#recovery-import-hint {
-    text-align: center;
-    padding: 1 0;
-}
-
-/* Delete Recovery Modal */
-#recovery-delete-modal {
-    width: 50;
-    height: auto;
-    background: $pfx-bg;
-    border: heavy #f43f5e;
-    padding: 2 3;
-}
-
-#recovery-delete-title {
-    text-style: bold;
-    color: #f43f5e;
-    text-align: center;
-    padding: 0 0 1 0;
-}
-
-/* ═══════════════════════════════════════════════════════════════════════════════
-   VIEW RECOVERY MODAL - FAIL-SAFE PROTOCOL VISUALIZATION
-   Theme: Rose (#f43f5e) for Emergency Recovery Display
-   ═══════════════════════════════════════════════════════════════════════════════ */
-
-#recovery-modal {
-    width: 100;
-    height: auto;
-    align: center middle;
-}
-
-#physical-recovery-card {
-    width: 96;
-    height: auto;
-    background: #0a0e27;
-    padding: 0;
-    margin: 0;
-    border: none;
-}
-
-#physical-recovery-card Static {
-    width: 96;
-    height: 1;
-    background: #0a0e27;
-    padding: 0;
-}
-
-/* Button container - styled with matching rose borders */
-#recovery-modal-buttons {
-    width: 96;
+.recovery-modal-wide #modal-buttons Button {
+    width: 24;
+    min-width: 24;
+    max-width: 24;
     height: 3;
-    background: #0a0e27;
-    align: center middle;
-    padding: 0;
-    border-left: outer #f43f5e;
-    border-right: outer #f43f5e;
-    border-bottom: outer #f43f5e;
-}
-
-#recovery-modal-buttons Button {
-    width: auto;
-    min-width: 12;
-    height: 1;
+    min-height: 3;
+    max-height: 3;
     margin: 0 1;
     padding: 0 2;
-    border: none;
-    text-style: bold;
 }
 
-#recovery-modal-buttons #copy-button {
-    background: #9f1239;
-    color: #fb7185;
+.recovery-modal-wide #import-button {
+    width: 24;
+    min-width: 24;
+    max-width: 24;
+    background: $pfx-salmon-dark;
+    color: $pfx-salmon;
+    border: solid $pfx-salmon;
 }
 
-#recovery-modal-buttons #copy-button:hover {
-    background: #fb7185;
-    color: #0f172a;
+.recovery-modal-wide #import-button:hover {
+    background: $pfx-salmon;
+    color: #000000;
 }
 
-#recovery-modal-buttons #copy-button:focus {
-    background: #be123c;
-    color: #fb7185;
-}
-
-#recovery-modal-buttons #close-button {
+.recovery-modal-wide #cancel-button {
+    width: 24;
+    min-width: 24;
+    max-width: 24;
     background: #1e293b;
     color: #94a3b8;
+    border: solid #475569;
 }
 
-#recovery-modal-buttons #close-button:hover {
-    background: #94a3b8;
-    color: #0f172a;
+.recovery-modal-wide #save-button {
+    width: 24;
+    min-width: 24;
+    max-width: 24;
+    background: #166534;
+    color: #22c55e;
+    border: solid #22c55e;
 }
 
-#recovery-modal-buttons #close-button:focus {
-    background: #334155;
-    color: #94a3b8;
-}
+/* Legacy Recovery modal styles removed - now uses standard #pwd-modal pattern */
 
 /* ═══════════════════════════════════════════════════════════════════════════════
    SECURE NOTES SCREEN - ENCRYPTED DATA SHARDS THEME


### PR DESCRIPTION
## Summary

Implement full UI parity across all vault screens with distinct accent colors, achieving a cohesive Operator cyberpunk aesthetic where each screen has its own color identity.

## Motivation

The Recovery screen needed to match the ENV VAR screen structure, and all screens needed consistent accent color application for visual coherence and professional polish.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure / CI / tooling
- [x] Refactoring (no functional changes)

## Changes

### Screen Accent Colors
| Screen | Accent Color |
|--------|--------------|
| Passwords | Purple (#8b5cf6) |
| Phones | Pink (#ec4899) |
| Cards | Green (#22c55e) |
| Notes | Amber (#fde047) |
| Envs | Indigo (#818cf8) |
| Recovery | Salmon (#ff6f6f) |
| Main Menu | Cyan (#00FFFF) |

### Unified Elements Per Screen
- Header branding text color
- Header/footer border lines
- Grid pane separator border
- Inspector header block background
- Inspector section underlines
- Terminal/preview box borders
- Pane footer border

### Recovery Screen Refactor
- Match EnvsScreen structure exactly
- Migrate modals to standard `#pwd-modal` pattern
- Inspector: field grid, stats, preview terminal, metadata
- Remove 200+ lines of obsolete modal styles

### Main Menu Updates
- Cyan borders for header/footer
- Dashboard digits match each screen's accent color

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] N/A (documentation only)

## Risk Assessment

**Risk level:** Low

**Areas affected:**
- UI styling only (TCSS)
- Screen compose methods (color tokens)
- No business logic changes

## Security Considerations

- [x] N/A (no security-sensitive changes)

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format