### PR TITLE
fix(tests): reduce PIN uniqueness test sample size to avoid birthday paradox

### DIFF
--- a/tests/utils/test_password_generator.py
+++ b/tests/utils/test_password_generator.py
@@ -595,9 +595,11 @@ class TestSecurityProperties:
 
     def test_pin_uses_secrets_module(self) -> None:
         """PIN generation uses cryptographic randomness."""
-        pins = [generate_pin(length=6) for _ in range(500)]
-        # 6-digit PIN has 1M possibilities, 500 samples should be unique
-        assert len(set(pins)) == 500
+        # Use 100 samples to avoid birthday paradox collisions
+        # (500 samples from 1M has ~12% collision chance)
+        pins = [generate_pin(length=6) for _ in range(100)]
+        # 6-digit PIN has 1M possibilities, 100 samples should be unique
+        assert len(set(pins)) == 100
 
     def test_no_sequential_patterns_in_passwords(self) -> None:
         """Passwords don't contain obvious sequential patterns."""


### PR DESCRIPTION
## Summary

Fix flaky test `test_pin_uses_secrets_module` that was failing intermittently in CI due to birthday paradox collisions.

## Motivation

The test expected 500 unique 6-digit PINs, but with 500 samples from 1,000,000 possibilities, the birthday paradox gives approximately **12% probability** of at least one collision:

```
P(collision) ≈ 1 - e^(-n²/(2N))
P ≈ 1 - e^(-500²/(2×1,000,000))
P ≈ 1 - e^(-0.125)
P ≈ 11.8%
```

This means roughly 1 in 8 CI runs would fail randomly.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure / CI / tooling
- [ ] Refactoring (no functional changes)

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] N/A (documentation only)

Ran the test 100 times locally with no failures.

## Risk Assessment

**Risk level:** Low

**Areas affected:** Test suite only, no production code changes.

## Security Considerations

- [ ] No credentials or secrets exposed
- [ ] Sensitive data properly cleared from memory
- [ ] File permissions verified (0600/0700)
- [x] N/A (no security-sensitive changes)

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format