### PR TITLE
fix(ui): preserve _esc_pending flag for double-ESC pattern

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ markers = [
     "security: Security tests - threat model and invariant validation",
     "slow: Slow tests (>1s) - excluded from fast runs",
     "edge: Edge case tests - failure paths and hardening scenarios",
+    "regression: Regression tests - bug fix contracts to prevent recurrence",
 ]
 filterwarnings = [
     "error",


### PR DESCRIPTION
## Summary

Fix for the double-ESC exit pattern in VaultInterceptorScreen. The `watch_mode()` method was unconditionally resetting `_esc_pending=False` on every mode change, which broke the double-ESC detection when transitioning from COMMAND to SEARCH mode.

## Motivation

Users expect to quickly exit the search modal by pressing ESC twice from COMMAND mode. The bug caused inconsistent behavior where multiple ESC presses might be required to close the modal.

Fixes #94

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure / CI / tooling
- [ ] Refactoring (no functional changes)

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] N/A (documentation only)

**Tests added:**
- `test_double_esc_from_command_closes_modal` - Primary regression test
- `test_double_esc_closes_even_with_input_text` - Double-ESC bypasses text clearing
- `test_typing_after_first_esc_cancels_double_esc` - Typing resets pattern
- `test_entering_command_mode_resets_esc_pending` - Prevents stale state
- `test_rapid_double_esc_sequence` - Fast typist simulation
- `test_single_esc_in_search_mode_normal_behavior` - Normal ESC preserved

## Risk Assessment

**Risk level:** Low

**Areas affected:**
- `passfx/widgets/search_overlay.py` - ESC handling logic only
- Existing keyboard workflows preserved
- No changes to data models or crypto operations

## Security Considerations

- [x] No credentials or secrets exposed
- [x] Sensitive data properly cleared from memory
- [x] File permissions verified (0600/0700)
- [ ] N/A (no security-sensitive changes)

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally (1280 passed)
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format