### PR TITLE
fix(ci): add passfx.app to coverage collection in ui-tests job

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -185,6 +185,7 @@ jobs:
         run: |
           pytest tests/ui tests/app tests/screens \
             --cov=passfx.screens \
+            --cov=passfx.app \
             --cov-report=term-missing \
             --cov-report=xml:coverage-ui.xml \
             --cov-fail-under=0 \


### PR DESCRIPTION
## Summary

Fix Codecov reporting for `passfx/app.py` by adding `--cov=passfx.app` to the ui-tests job.

## Motivation

The `ui-tests` CI job runs `tests/app/` but was only collecting coverage for `passfx.screens`. This caused Codecov to report `app.py` as uncovered despite having 137 comprehensive tests with 97% local coverage.

**Root cause:** Line 187 had `--cov=passfx.screens` but not `--cov=passfx.app`.

## Type of Change

- [x] Infrastructure / CI / tooling

## Testing

- [x] N/A (documentation only)

After this merge, the next CI run will upload proper coverage for `app.py` to Codecov.

## Risk Assessment

**Risk level:** Low

**Areas affected:**
- CI coverage collection only
- No production code changes

## Security Considerations

- [x] N/A (no security-sensitive changes)

## Checklist

- [x] Code follows project style guidelines
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] Commit messages follow conventional format