### PR TITLE
feat(ui): expose global search shortcut (^K) in footer across screens

### DIFF
--- a/passfx/screens/cards.py
+++ b/passfx/screens/cards.py
@@ -758,6 +758,9 @@ class CardsScreen(Screen):
                     yield Static(f"[bold {c['primary']}] V [/]", classes="keycap")
                     yield Static(f"[{c['muted']}]View[/]", classes="keycap-label")
                 with Horizontal(classes="keycap-group"):
+                    yield Static(f"[bold {c['primary']}] ^K [/]", classes="keycap")
+                    yield Static(f"[{c['muted']}]Search[/]", classes="keycap-label")
+                with Horizontal(classes="keycap-group"):
                     yield Static(f"[bold {c['primary']}] ESC [/]", classes="keycap")
                     yield Static(f"[{c['muted']}]Back[/]", classes="keycap-label")
 

--- a/passfx/screens/envs.py
+++ b/passfx/screens/envs.py
@@ -606,6 +606,9 @@ class EnvsScreen(Screen):
                     yield Static(f"[bold {c['primary']}] V [/]", classes="keycap")
                     yield Static(f"[{c['muted']}]View[/]", classes="keycap-label")
                 with Horizontal(classes="keycap-group"):
+                    yield Static(f"[bold {c['primary']}] ^K [/]", classes="keycap")
+                    yield Static(f"[{c['muted']}]Search[/]", classes="keycap-label")
+                with Horizontal(classes="keycap-group"):
                     yield Static(f"[bold {c['primary']}] ESC [/]", classes="keycap")
                     yield Static(f"[{c['muted']}]Back[/]", classes="keycap-label")
 

--- a/passfx/screens/generator.py
+++ b/passfx/screens/generator.py
@@ -274,6 +274,9 @@ class GeneratorScreen(Screen):
                     yield Static("[bold #00FFFF] S [/]", classes="keycap")
                     yield Static("[#666666]Save[/]", classes="keycap-label")
                 with Horizontal(classes="keycap-group"):
+                    yield Static("[bold #00FFFF] ^K [/]", classes="keycap")
+                    yield Static("[#666666]Search[/]", classes="keycap-label")
+                with Horizontal(classes="keycap-group"):
                     yield Static("[bold #00FFFF] ESC [/]", classes="keycap")
                     yield Static("[#666666]Back[/]", classes="keycap-label")
 

--- a/passfx/screens/help.py
+++ b/passfx/screens/help.py
@@ -228,7 +228,12 @@ class HelpScreen(ModalScreen[None]):
 
             # Footer - Mechanical keycap hints
             yield KeycapFooter(
-                hints=[("↑↓", "Navigate"), ("←→", "Switch Pane"), ("ESC", "Close")],
+                hints=[
+                    ("↑↓", "Navigate"),
+                    ("←→", "Switch Pane"),
+                    ("^K", "Search"),
+                    ("ESC", "Close"),
+                ],
                 footer_id="help-footer",
             )
 

--- a/passfx/screens/main_menu.py
+++ b/passfx/screens/main_menu.py
@@ -258,6 +258,9 @@ class MainMenuScreen(Screen):
                     yield Static("[bold #00FFFF] / [/]", classes="keycap")
                     yield Static("[#666666]Terminal[/]", classes="keycap-label")
                 with Horizontal(classes="keycap-group"):
+                    yield Static("[bold #00FFFF] ^K [/]", classes="keycap")
+                    yield Static("[#666666]Search[/]", classes="keycap-label")
+                with Horizontal(classes="keycap-group"):
                     yield Static("[bold #00FFFF] ESC [/]", classes="keycap")
                     yield Static("[#666666]Back[/]", classes="keycap-label")
                 with Horizontal(classes="keycap-group"):

--- a/passfx/screens/notes.py
+++ b/passfx/screens/notes.py
@@ -431,6 +431,9 @@ class NotesScreen(Screen):
                     yield Static(f"[bold {c['primary']}] V [/]", classes="keycap")
                     yield Static(f"[{c['muted']}]View[/]", classes="keycap-label")
                 with Horizontal(classes="keycap-group"):
+                    yield Static(f"[bold {c['primary']}] ^K [/]", classes="keycap")
+                    yield Static(f"[{c['muted']}]Search[/]", classes="keycap-label")
+                with Horizontal(classes="keycap-group"):
                     yield Static(f"[bold {c['primary']}] ESC [/]", classes="keycap")
                     yield Static(f"[{c['muted']}]Back[/]", classes="keycap-label")
 

--- a/passfx/screens/passwords.py
+++ b/passfx/screens/passwords.py
@@ -553,6 +553,9 @@ class PasswordsScreen(Screen):
                     yield Static(f"[bold {c['primary']}] V [/]", classes="keycap")
                     yield Static(f"[{c['muted']}]View[/]", classes="keycap-label")
                 with Horizontal(classes="keycap-group"):
+                    yield Static(f"[bold {c['primary']}] ^K [/]", classes="keycap")
+                    yield Static(f"[{c['muted']}]Search[/]", classes="keycap-label")
+                with Horizontal(classes="keycap-group"):
                     yield Static(f"[bold {c['primary']}] ESC [/]", classes="keycap")
                     yield Static(f"[{c['muted']}]Back[/]", classes="keycap-label")
 

--- a/passfx/screens/phones.py
+++ b/passfx/screens/phones.py
@@ -496,6 +496,9 @@ class PhonesScreen(Screen):
                     yield Static(f"[bold {c['primary']}] V [/]", classes="keycap")
                     yield Static(f"[{c['muted']}]View[/]", classes="keycap-label")
                 with Horizontal(classes="keycap-group"):
+                    yield Static(f"[bold {c['primary']}] ^K [/]", classes="keycap")
+                    yield Static(f"[{c['muted']}]Search[/]", classes="keycap-label")
+                with Horizontal(classes="keycap-group"):
                     yield Static(f"[bold {c['primary']}] ESC [/]", classes="keycap")
                     yield Static(f"[{c['muted']}]Back[/]", classes="keycap-label")
 

--- a/passfx/screens/recovery.py
+++ b/passfx/screens/recovery.py
@@ -569,6 +569,9 @@ class RecoveryScreen(Screen):
                     yield Static(f"[bold {c['primary']}] V [/]", classes="keycap")
                     yield Static(f"[{c['muted']}]View[/]", classes="keycap-label")
                 with Horizontal(classes="keycap-group"):
+                    yield Static(f"[bold {c['primary']}] ^K [/]", classes="keycap")
+                    yield Static(f"[{c['muted']}]Search[/]", classes="keycap-label")
+                with Horizontal(classes="keycap-group"):
                     yield Static(f"[bold {c['primary']}] ESC [/]", classes="keycap")
                     yield Static(f"[{c['muted']}]Back[/]", classes="keycap-label")
 

--- a/passfx/screens/settings.py
+++ b/passfx/screens/settings.py
@@ -465,7 +465,12 @@ class SettingsScreen(Screen):
 
         # Footer with keycaps
         yield KeycapFooter(
-            hints=[("↑↓", "Navigate"), ("TAB", "Focus"), ("ESC", "Back")],
+            hints=[
+                ("↑↓", "Navigate"),
+                ("TAB", "Focus"),
+                ("^K", "Search"),
+                ("ESC", "Back"),
+            ],
             footer_id="settings-footer",
             label=" SETTINGS ",
         )

--- a/passfx/styles/passfx.tcss
+++ b/passfx/styles/passfx.tcss
@@ -4795,12 +4795,30 @@ SettingsScreen {
     content-align: center middle;
 }
 
-#settings-footer-keys {
-    width: 1fr;
+/* Keycap styling within settings footer */
+#settings-footer .keycap-group {
+    width: auto;
     height: 3;
-    background: $operator-black;
-    align: left middle;
-    padding-left: 2;
+    margin-right: 2;
+    align: center middle;
+}
+
+#settings-footer .keycap {
+    width: auto;
+    height: auto;
+    min-width: 5;
+    background: $operator-surface;
+    color: $operator-primary;
+    text-style: bold;
+    padding: 0 1;
+}
+
+#settings-footer .keycap-label {
+    width: auto;
+    height: auto;
+    background: transparent;
+    margin-left: 1;
+    color: $operator-muted;
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════

--- a/passfx/widgets/keycap_footer.py
+++ b/passfx/widgets/keycap_footer.py
@@ -11,6 +11,9 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal
 from textual.widgets import Static
 
+# Global search shortcut - single source of truth for all footer displays
+GLOBAL_SEARCH_HINT: tuple[str, str] = ("^K", "Search")
+
 
 class KeycapHint(Horizontal):
     """Single keycap hint showing a key and its action."""


### PR DESCRIPTION
## Summary

Add visible `^K Search` keycap to footer on all applicable screens to improve discoverability of the global search feature (Ctrl+K).

## Motivation

The global search feature (`Ctrl+K`) exists and works but was not discoverable from the UI. Users would only find it by reading documentation or trying keyboard shortcuts. This change makes search a first-class visible action in the footer command strip.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure / CI / tooling
- [ ] Refactoring (no functional changes)

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] N/A (documentation only)

**Manual testing:**
- Verified `^K Search` keycap appears on Main Menu, all vault screens, Generator, Settings, and Help
- Verified keycap does NOT appear on Login screen (no footer) or search overlay (inside modal)
- Verified `Ctrl+K` still triggers search correctly
- Verified visual consistency with existing keycaps (cyan keys, muted labels)
- Verified Settings footer keycaps are now vertically centered

## Risk Assessment

**Risk level:** Low

**Areas affected:**
- Footer display on 10 screens (UI only)
- No behavioral changes to search functionality
- No changes to keybindings

## Security Considerations

- [x] N/A (no security-sensitive changes)

Pure UI affordance change - adds visual indicator for existing functionality.

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format