### PR TITLE
fix(ui): standardize header and selector styling across vault screens

### DIFF
--- a/passfx/styles/passfx.tcss
+++ b/passfx/styles/passfx.tcss
@@ -1112,6 +1112,15 @@ PasswordsScreen #header-branding {
     text-style: bold;
 }
 
+PasswordsScreen #header-right {
+    background: $operator-black;
+    color: $operator-muted;
+    width: 1fr;
+    height: 100%;
+    align: right middle;
+    padding-right: 2;
+}
+
 PasswordsScreen .screen-header {
     text-style: bold;
 }
@@ -1390,6 +1399,15 @@ PhonesScreen #app-header {
 PhonesScreen #header-branding {
     color: $operator-primary;
     text-style: bold;
+}
+
+PhonesScreen #header-right {
+    background: $operator-black;
+    color: $operator-muted;
+    width: 1fr;
+    height: 100%;
+    align: right middle;
+    padding-right: 2;
 }
 
 PhonesScreen .screen-header {
@@ -3223,6 +3241,15 @@ EnvsScreen #header-branding {
     background: $operator-black;
 }
 
+EnvsScreen #header-right {
+    background: $operator-black;
+    color: $operator-muted;
+    width: 1fr;
+    height: 100%;
+    align: right middle;
+    padding-right: 2;
+}
+
 EnvsScreen #app-footer {
     background: $operator-black;
     border-top: heavy $pfx-indigo-dim;
@@ -3357,16 +3384,16 @@ EnvsScreen #envs-table:focus {
     border: none;
 }
 
-/* Data stream selection - prominent indigo highlight with cyan border */
+/* Data stream selection - locked target feel with left border */
 EnvsScreen #envs-table > .datatable--cursor {
-    background: #3730a3;
+    background: #0a0a1a;
     color: $pfx-fg;
     text-style: bold;
     border-left: heavy $operator-primary;
 }
 
 EnvsScreen #envs-table > .datatable--cursor:hover {
-    background: #4338ca;
+    background: #0a0a1a;
 }
 
 /* Headers - Indigo accent for system labels */
@@ -3864,6 +3891,15 @@ RecoveryScreen #header-branding {
     background: $operator-black;
 }
 
+RecoveryScreen #header-right {
+    background: $operator-black;
+    color: $operator-muted;
+    width: 1fr;
+    height: 100%;
+    align: right middle;
+    padding-right: 2;
+}
+
 RecoveryScreen #app-footer {
     background: $operator-black;
     border-top: heavy $pfx-salmon-dim;
@@ -3998,16 +4034,16 @@ RecoveryScreen #recovery-table:focus {
     border: none;
 }
 
-/* Data stream selection - prominent salmon highlight with cyan border */
+/* Data stream selection - locked target feel with left border */
 RecoveryScreen #recovery-table > .datatable--cursor {
-    background: #993f3f;
+    background: #1a0a0a;
     color: $pfx-fg;
     text-style: bold;
     border-left: heavy $operator-primary;
 }
 
 RecoveryScreen #recovery-table > .datatable--cursor:hover {
-    background: #b34d4d;
+    background: #1a0a0a;
 }
 
 /* Headers - Salmon accent for fail-safe labels */


### PR DESCRIPTION
## Summary

Standardizes UI styling across vault screens for visual consistency:
- Fixes ENCRYPTED status text alignment (anchored to right) on Passwords, Phones, Env Vars, and Recovery screens
- Normalizes DataTable selector/cursor colors on Env Vars and Recovery screens to match the dim styling used elsewhere

## Motivation

Visual inconsistency between screens:
1. ENCRYPTED status was not properly anchored to the right on most vault screens (worked on Cards screen only)
2. Env Vars and Recovery screens used deep/bright cursor colors while other screens used dim backgrounds

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure / CI / tooling
- [ ] Refactoring (no functional changes)

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] N/A (documentation only)

## Risk Assessment

**Risk level:** Low

**Areas affected:**
- CSS styling only (passfx.tcss)
- No logic changes
- Visual/cosmetic fix

## Security Considerations

- [ ] No credentials or secrets exposed
- [ ] Sensitive data properly cleared from memory
- [ ] File permissions verified (0600/0700)
- [x] N/A (no security-sensitive changes)

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format