### PR TITLE
style(ui): redesign password modals to wide-format console layout

### DIFF
--- a/passfx/screens/passwords.py
+++ b/passfx/screens/passwords.py
@@ -145,50 +145,60 @@ def _get_avatar_bg_color(label: str) -> str:
 
 
 class AddPasswordModal(ModalScreen[EmailCredential | None]):
-    """Modal for adding a new password - Operator Grade Secure Write Console."""
+    """Modal for adding a new password - Wide Console Panel Layout."""
 
     BINDINGS = [
         Binding("escape", "cancel", "Cancel"),
     ]
 
     def compose(self) -> ComposeResult:
-        """Create the Operator-grade modal layout."""
-        with Vertical(id="pwd-modal", classes="secure-terminal"):
+        """Create wide-format console panel layout."""
+        with Vertical(id="pwd-modal", classes="password-modal-wide"):
             # HUD Header with status indicator
             with Vertical(classes="modal-header"):
                 with Horizontal(classes="modal-header-row"):
                     yield Static("[ :: SECURE WRITE PROTOCOL :: ]", id="modal-title")
                     yield Static("STATUS: OPEN", classes="modal-status")
 
-            # Form Body
-            with Vertical(id="pwd-form"):
-                # Row 1: Label (System)
-                yield Label("> TARGET_SYSTEM", classes="input-label")
-                yield Input(placeholder="e.g. GITHUB_MAIN", id="label-input")
+            # Form Body - Grid Layout
+            with Vertical(id="pwd-form", classes="pwd-form-grid"):
+                # Row 1 (Identity): Title spans full width
+                with Vertical(classes="form-row form-row-full"):
+                    yield Label("> TARGET_SYSTEM", classes="input-label")
+                    yield Input(placeholder="e.g. GITHUB_MAIN", id="label-input")
 
-                # Row 2: Email (Identity)
-                yield Label("> USER_IDENTITY", classes="input-label")
-                yield Input(placeholder="username@host", id="email-input")
+                # Row 2 (Credentials): Username + Password side-by-side
+                with Horizontal(classes="form-row form-row-split"):
+                    with Vertical(classes="form-col"):
+                        yield Label("> USER_IDENTITY", classes="input-label")
+                        yield Input(placeholder="username@host", id="email-input")
+                    with Vertical(classes="form-col"):
+                        yield Label("> ACCESS_KEY", classes="input-label")
+                        yield Input(
+                            placeholder="••••••••••••",
+                            password=True,
+                            id="password-input",
+                        )
 
-                # Row 3: Password (Secret) - sensitive field
-                yield Label("> ACCESS_KEY", classes="input-label")
-                yield Input(
-                    placeholder="••••••••••••", password=True, id="password-input"
-                )
+                # Row 3 (Access): URL spans full width
+                with Vertical(classes="form-row form-row-full"):
+                    yield Label("> SERVICE_URL", classes="input-label")
+                    yield Input(placeholder="https://example.com", id="url-input")
 
-                # Row 4: Notes
-                yield Label("> METADATA", classes="input-label")
-                yield Input(placeholder="OPTIONAL_NOTES", id="notes-input")
+                # Row 4 (Notes): Full width at bottom
+                with Vertical(classes="form-row form-row-full"):
+                    yield Label("> METADATA", classes="input-label")
+                    yield Input(placeholder="OPTIONAL_NOTES", id="notes-input")
 
-            # Footer Actions - right aligned
-            with Horizontal(id="modal-buttons"):
+            # Footer Actions - docked bottom, right aligned
+            with Horizontal(id="modal-buttons", classes="modal-footer"):
                 yield Button(r"\[ ABORT ]", variant="default", id="cancel-button")
                 yield Button(
                     r"\[ ENCRYPT & COMMIT ]", variant="primary", id="save-button"
                 )
 
     def on_mount(self) -> None:
-        """Focus first input."""
+        """Focus first input (Title field)."""
         self.query_one("#label-input", Input).focus()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
@@ -223,7 +233,7 @@ class AddPasswordModal(ModalScreen[EmailCredential | None]):
 
 
 class EditPasswordModal(ModalScreen[dict | None]):
-    """Modal for editing a password - Operator Grade Secure Write Console."""
+    """Modal for editing a password - Wide Console Panel Layout."""
 
     BINDINGS = [
         Binding("escape", "cancel", "Cancel"),
@@ -234,8 +244,8 @@ class EditPasswordModal(ModalScreen[dict | None]):
         self.credential = credential
 
     def compose(self) -> ComposeResult:
-        """Create the Operator-grade modal layout."""
-        with Vertical(id="pwd-modal", classes="secure-terminal"):
+        """Create wide-format console panel layout."""
+        with Vertical(id="pwd-modal", classes="password-modal-wide"):
             # HUD Header with status indicator
             with Vertical(classes="modal-header"):
                 with Horizontal(classes="modal-header-row"):
@@ -245,38 +255,64 @@ class EditPasswordModal(ModalScreen[dict | None]):
                     )
                     yield Static("STATUS: EDIT", classes="modal-status")
 
-            with Vertical(id="pwd-form"):
-                yield Label("> TARGET_SYSTEM", classes="input-label")
-                yield Input(
-                    value=self.credential.label,
-                    placeholder="e.g. GITHUB_MAIN",
-                    id="label-input",
-                )
+            # Form Body - Grid Layout
+            with Vertical(id="pwd-form", classes="pwd-form-grid"):
+                # Row 1 (Identity): Title spans full width
+                with Vertical(classes="form-row form-row-full"):
+                    yield Label("> TARGET_SYSTEM", classes="input-label")
+                    yield Input(
+                        value=self.credential.label,
+                        placeholder="e.g. GITHUB_MAIN",
+                        id="label-input",
+                    )
 
-                yield Label("> USER_IDENTITY", classes="input-label")
-                yield Input(
-                    value=self.credential.email,
-                    placeholder="username@host",
-                    id="email-input",
-                )
+                # Row 2 (Credentials): Username + Password side-by-side
+                with Horizontal(classes="form-row form-row-split"):
+                    with Vertical(classes="form-col"):
+                        yield Label("> USER_IDENTITY", classes="input-label")
+                        yield Input(
+                            value=self.credential.email,
+                            placeholder="username@host",
+                            id="email-input",
+                        )
+                    with Vertical(classes="form-col"):
+                        yield Label(
+                            "> ACCESS_KEY [BLANK = KEEP]", classes="input-label"
+                        )
+                        yield Input(
+                            placeholder="••••••••••••",
+                            password=True,
+                            id="password-input",
+                        )
 
-                yield Label("> ACCESS_KEY [BLANK = KEEP]", classes="input-label")
-                yield Input(
-                    placeholder="••••••••••••", password=True, id="password-input"
-                )
+                # Row 3 (Access): URL spans full width
+                with Vertical(classes="form-row form-row-full"):
+                    yield Label("> SERVICE_URL", classes="input-label")
+                    yield Input(
+                        value=getattr(self.credential, "url", "") or "",
+                        placeholder="https://example.com",
+                        id="url-input",
+                    )
 
-                yield Label("> METADATA", classes="input-label")
-                yield Input(
-                    value=self.credential.notes or "",
-                    placeholder="OPTIONAL_NOTES",
-                    id="notes-input",
-                )
+                # Row 4 (Notes): Full width at bottom
+                with Vertical(classes="form-row form-row-full"):
+                    yield Label("> METADATA", classes="input-label")
+                    yield Input(
+                        value=self.credential.notes or "",
+                        placeholder="OPTIONAL_NOTES",
+                        id="notes-input",
+                    )
 
-            with Horizontal(id="modal-buttons"):
+            # Footer Actions - docked bottom, right aligned
+            with Horizontal(id="modal-buttons", classes="modal-footer"):
                 yield Button(r"\[ ABORT ]", id="cancel-button")
                 yield Button(
                     r"\[ ENCRYPT & COMMIT ]", variant="primary", id="save-button"
                 )
+
+    def on_mount(self) -> None:
+        """Focus first input (Title field)."""
+        self.query_one("#label-input", Input).focus()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle button press."""
@@ -358,7 +394,7 @@ class ConfirmDeleteModal(ModalScreen[bool]):
 
 
 class ViewPasswordModal(ModalScreen[None]):
-    """Modal for viewing a password - Operator Grade Secure Read Console."""
+    """Modal for viewing a password - Wide Console Panel Layout."""
 
     BINDINGS = [
         Binding("escape", "close", "Close"),
@@ -370,7 +406,7 @@ class ViewPasswordModal(ModalScreen[None]):
         self.credential = credential
 
     def compose(self) -> ComposeResult:
-        """Create the Operator-grade view modal layout."""
+        """Create wide-format console panel view layout."""
         # Get password strength for visual indicator
         strength = check_strength(self.credential.password)
         strength_color = _get_strength_color(strength.score)
@@ -379,54 +415,62 @@ class ViewPasswordModal(ModalScreen[None]):
             f"[{strength_color}]{'█' * filled}[/][#1e293b]{'░' * (5 - filled)}[/]"
         )
 
-        with Vertical(id="pwd-modal", classes="secure-terminal"):
+        with Vertical(id="pwd-modal", classes="password-modal-wide"):
             # HUD Header with status indicator
             with Vertical(classes="modal-header"):
                 with Horizontal(classes="modal-header-row"):
                     yield Static("[ :: SECURE READ PROTOCOL :: ]", id="modal-title")
                     yield Static("STATUS: DECRYPTED", classes="modal-status")
 
-            # Data Display Body
-            with Vertical(id="pwd-form"):
-                # Row 1: Label (System)
-                yield Label("> TARGET_SYSTEM", classes="input-label")
-                yield Static(
-                    f"  {self.credential.label}", classes="view-value", id="label-value"
-                )
-
-                # Row 2: Email (Identity)
-                yield Label("> USER_IDENTITY", classes="input-label")
-                yield Static(
-                    f"  {self.credential.email}", classes="view-value", id="email-value"
-                )
-
-                # Row 3: Password (Secret)
-                yield Label("> ACCESS_KEY", classes="input-label")
-                yield Static(
-                    f"  [#22c55e]{self.credential.password}[/]",
-                    classes="view-value secret",
-                    id="password-value",
-                )
-
-                # Row 4: Security Level
-                yield Label("> SECURITY_LEVEL", classes="input-label")
-                yield Static(
-                    f"  {security_bars} [{strength_color}]{strength.label.upper()}[/]",
-                    classes="view-value",
-                    id="strength-value",
-                )
-
-                # Row 5: Notes (if present)
-                if self.credential.notes:
-                    yield Label("> METADATA", classes="input-label")
+            # Data Display Body - Grid Layout
+            with Vertical(id="pwd-form", classes="pwd-form-grid"):
+                # Row 1 (Identity): Title spans full width
+                with Vertical(classes="form-row form-row-full"):
+                    yield Label("> TARGET_SYSTEM", classes="input-label")
                     yield Static(
-                        f"  {self.credential.notes}",
+                        f"  {self.credential.label}",
                         classes="view-value",
-                        id="notes-value",
+                        id="label-value",
                     )
 
-            # Footer Actions - right aligned
-            with Horizontal(id="modal-buttons"):
+                # Row 2 (Credentials): Username + Password side-by-side
+                with Horizontal(classes="form-row form-row-split"):
+                    with Vertical(classes="form-col"):
+                        yield Label("> USER_IDENTITY", classes="input-label")
+                        yield Static(
+                            f"  {self.credential.email}",
+                            classes="view-value",
+                            id="email-value",
+                        )
+                    with Vertical(classes="form-col"):
+                        yield Label("> ACCESS_KEY", classes="input-label")
+                        yield Static(
+                            f"  [#22c55e]{self.credential.password}[/]",
+                            classes="view-value secret",
+                            id="password-value",
+                        )
+
+                # Row 3 (Security): Strength indicator spans full width
+                with Vertical(classes="form-row form-row-full"):
+                    yield Label("> SECURITY_LEVEL", classes="input-label")
+                    yield Static(
+                        f"  {security_bars} [{strength_color}]{strength.label.upper()}[/]",
+                        classes="view-value",
+                        id="strength-value",
+                    )
+
+                # Row 4 (Notes): Full width at bottom (if present)
+                if self.credential.notes:
+                    with Vertical(classes="form-row form-row-full"):
+                        yield Label("> METADATA", classes="input-label")
+                        yield Static(
+                            f"  {self.credential.notes}",
+                            classes="view-value",
+                            id="notes-value",
+                        )
+
+            # Footer Actions - docked bottom, right aligned
+            with Horizontal(id="modal-buttons", classes="modal-footer"):
                 yield Button(r"\[ DISMISS ]", variant="default", id="cancel-button")
                 yield Button(r"\[ COPY KEY ]", variant="primary", id="save-button")
 

--- a/passfx/styles/passfx.tcss
+++ b/passfx/styles/passfx.tcss
@@ -2558,6 +2558,198 @@ NotesScreen #notes-table > .datatable--odd-row {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
+   PASSWORD MODALS - WIDE CONSOLE PANEL LAYOUT
+   Wide-format horizontal layout for improved data density
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* Wide modal container - 90% width, max 120 for ultra-wide screens */
+#pwd-modal.password-modal-wide {
+    width: 90%;
+    max-width: 120;
+    min-width: 80;
+    height: auto;
+    max-height: 80%;
+    background: $operator-black;
+    border: heavy $operator-primary;
+    padding: 0;
+}
+
+/* Grid-based form container */
+.password-modal-wide .pwd-form-grid {
+    padding: 1 3;
+    background: $operator-black;
+    width: 100%;
+}
+
+/* Form row - base styles */
+.password-modal-wide .form-row {
+    width: 100%;
+    height: auto;
+    margin-bottom: 1;
+}
+
+/* Full width row (Title, URL, Notes) */
+.password-modal-wide .form-row-full {
+    width: 100%;
+}
+
+/* Split row - side-by-side fields (Username + Password) */
+.password-modal-wide .form-row-split {
+    width: 100%;
+    height: auto;
+    align: left top;
+}
+
+/* Column for side-by-side inputs (50% each) */
+.password-modal-wide .form-col {
+    width: 1fr;
+    height: auto;
+    padding-right: 2;
+}
+
+.password-modal-wide .form-col:last-child {
+    padding-right: 0;
+}
+
+/* Input labels - terminal style with prompt */
+.password-modal-wide .input-label {
+    color: $operator-secondary;
+    text-style: bold;
+    padding: 1 0 0 0;
+    margin: 0;
+    height: 1;
+}
+
+/* Terminal-style inputs - left border accent */
+.password-modal-wide Input {
+    background: $operator-surface;
+    border: none;
+    border-left: solid $operator-muted;
+    padding: 1 1 0 2;
+    margin: 0 0 0 0;
+    color: $pfx-fg;
+    width: 100%;
+    height: 3;
+}
+
+/* Focus state - purple accent with highlighted left border */
+.password-modal-wide Input:focus {
+    border-left: heavy $operator-secondary;
+    background: #0a0a12;
+}
+
+/* Password input styling */
+.password-modal-wide #password-input {
+    border-left: solid $pfx-success 50%;
+}
+
+.password-modal-wide #password-input:focus {
+    border-left: heavy $pfx-success;
+    background: #0a120a;
+}
+
+/* View value display - terminal output style */
+.password-modal-wide .view-value {
+    background: $operator-surface;
+    border: none;
+    border-left: solid $operator-muted;
+    padding: 0 1 0 2;
+    margin: 0;
+    color: $pfx-fg;
+    width: 100%;
+    height: 3;
+    content-align: left middle;
+}
+
+.password-modal-wide .view-value.secret {
+    border-left: solid $pfx-success 50%;
+    color: $pfx-success;
+}
+
+/* Modal footer - docked to bottom, right-aligned buttons */
+.password-modal-wide .modal-footer {
+    padding: 1 3 2 3;
+    align: right middle;
+    background: $operator-black;
+    border-top: solid $operator-muted 30%;
+    width: 100%;
+    height: auto;
+    dock: bottom;
+}
+
+/* Cancel button styling */
+.password-modal-wide #cancel-button {
+    background: transparent;
+    color: #64748b;
+    border: solid #475569;
+    min-width: 14;
+}
+
+.password-modal-wide #cancel-button:hover {
+    background: #1e293b;
+    color: #94a3b8;
+    border: solid #1e293b;
+}
+
+.password-modal-wide #cancel-button:focus {
+    background: #1e293b;
+    color: #e2e8f0;
+    border: solid #1e293b;
+}
+
+/* Save button styling - green accent */
+.password-modal-wide #save-button {
+    background: transparent;
+    color: $pfx-success;
+    border: solid $pfx-success;
+    text-style: bold;
+    min-width: 24;
+}
+
+.password-modal-wide #save-button:hover {
+    background: $pfx-success;
+    color: $operator-black;
+}
+
+.password-modal-wide #save-button:focus {
+    background: $pfx-success;
+    color: $operator-black;
+    text-style: bold;
+}
+
+/* HUD Header for wide modals */
+.password-modal-wide .modal-header {
+    width: 100%;
+    height: auto;
+    background: $operator-black;
+    padding: 1 2;
+    border-bottom: heavy $operator-primary;
+}
+
+.password-modal-wide .modal-header-row {
+    width: 100%;
+    height: 1;
+    align: left middle;
+}
+
+.password-modal-wide #modal-title {
+    text-style: bold;
+    color: $operator-primary;
+    text-align: left;
+    padding: 0;
+    margin: 0;
+    width: 1fr;
+    border: none;
+}
+
+.password-modal-wide .modal-status {
+    width: auto;
+    height: 1;
+    color: $pfx-success;
+    text-style: bold;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
    GENERATOR SCREEN - OPERATOR THEME CRYPTO CONSOLE
    Theme: Cyan (#00FFFF) primary, Pure Black background
    ═══════════════════════════════════════════════════════════════════════════ */


### PR DESCRIPTION
## Summary

Redesign Password modals (Add, View, Edit) from narrow vertical card layout to wide horizontal console panel layout for improved data density and visual consistency with the Main Menu dashboard aesthetic.

## Motivation

The current Password modals use a narrow (~60 char) vertical "card" layout that clashes with the wider, dashboard-style aesthetic of the Main Menu and Command Centre. This PR refactors the modal structure to use a wide-format horizontal layout (90% terminal width) that:
- Increases data density without scrolling
- Aligns with the system's "hacker terminal" visual language
- Displays credentials side-by-side (Username + Password on the same row)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure / CI / tooling
- [x] Refactoring (no functional changes)

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] N/A (documentation only)

**Test Details:**
- All 1431 existing tests pass
- Code quality checks (ruff, mypy, bandit) pass
- Pre-commit hooks pass

## Risk Assessment

**Risk level:** Low

**Areas affected:**
- `passfx/screens/passwords.py` - Add/Edit/View modal compose methods
- `passfx/styles/passfx.tcss` - New `.password-modal-wide` CSS classes

No changes to business logic, data flow, or security-sensitive code.

## Security Considerations

- [x] N/A (no security-sensitive changes)

This is a pure UI/styling refactor with no changes to credential handling, encryption, or storage.

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format