### PR TITLE
style(ui): redesign phone modals to wide-format console layout

### DIFF
--- a/passfx/screens/phones.py
+++ b/passfx/screens/phones.py
@@ -95,42 +95,49 @@ def _get_strength_color(score: int) -> str:
 
 
 class AddPhoneModal(ModalScreen[PhoneCredential | None]):
-    """Modal for adding a new phone credential - Operator Grade Secure Write Console."""
+    """Modal for adding a new phone credential - Wide Console Panel Layout."""
 
     BINDINGS = [
         Binding("escape", "cancel", "Cancel"),
     ]
 
     def compose(self) -> ComposeResult:
-        """Create the Operator-grade modal layout."""
-        with Vertical(id="pwd-modal", classes="secure-terminal"):
+        """Create wide-format console panel layout."""
+        with Vertical(id="pwd-modal", classes="phone-modal-wide"):
             # HUD Header with status indicator
             with Vertical(classes="modal-header"):
                 with Horizontal(classes="modal-header-row"):
                     yield Static("[ :: SECURE WRITE PROTOCOL :: ]", id="modal-title")
                     yield Static("STATUS: OPEN", classes="modal-status")
 
-            # Form Body
-            with Vertical(id="pwd-form"):
-                # Row 1: Label (Device)
-                yield Label("> TARGET_DEVICE", classes="input-label")
-                yield Input(placeholder="e.g. BANK_HOTLINE", id="label-input")
+            # Form Body - Grid Layout
+            with Vertical(id="pwd-form", classes="pwd-form-grid"):
+                # Row 1 (Identity): Device Label spans full width
+                with Vertical(classes="form-row form-row-full"):
+                    yield Label("> TARGET_DEVICE", classes="input-label")
+                    yield Input(placeholder="e.g. BANK_HOTLINE", id="label-input")
 
-                # Row 2: Phone (Uplink)
-                yield Label("> UPLINK_NUMBER", classes="input-label")
-                yield Input(placeholder="+1 555 000 0000", id="phone-input")
+                # Row 2 (Credentials): Phone + PIN side-by-side
+                with Horizontal(classes="form-row form-row-split"):
+                    with Vertical(classes="form-col"):
+                        yield Label("> UPLINK_NUMBER", classes="input-label")
+                        yield Input(placeholder="+1 555 000 0000", id="phone-input")
+                    with Vertical(classes="form-col"):
+                        yield Label("> ACCESS_PIN", classes="input-label")
+                        yield Input(
+                            placeholder="••••••",
+                            password=True,
+                            id="pin-input",
+                        )
 
-                # Row 3: PIN (Access Code) - sensitive field
-                yield Label("> ACCESS_PIN", classes="input-label")
-                yield Input(placeholder="••••••", password=True, id="pin-input")
+                # Row 3 (Notes): Full width at bottom
+                with Vertical(classes="form-row form-row-full"):
+                    yield Label("> METADATA", classes="input-label")
+                    yield Input(placeholder="OPTIONAL_NOTES", id="notes-input")
 
-                # Row 4: Notes
-                yield Label("> METADATA", classes="input-label")
-                yield Input(placeholder="OPTIONAL_NOTES", id="notes-input")
-
-            # Footer Actions - right aligned
-            with Horizontal(id="modal-buttons"):
-                yield Button(r"\[ ABORT ]", id="cancel-button")
+            # Footer Actions - docked bottom, right aligned
+            with Horizontal(id="modal-buttons", classes="modal-footer"):
+                yield Button(r"\[ ABORT ]", variant="default", id="cancel-button")
                 yield Button(
                     r"\[ ENCRYPT & COMMIT ]", variant="primary", id="save-button"
                 )
@@ -171,7 +178,7 @@ class AddPhoneModal(ModalScreen[PhoneCredential | None]):
 
 
 class EditPhoneModal(ModalScreen[dict | None]):
-    """Modal for editing a phone credential - Operator Grade Secure Write Console."""
+    """Modal for editing a phone credential - Wide Console Panel Layout."""
 
     BINDINGS = [
         Binding("escape", "cancel", "Cancel"),
@@ -182,8 +189,8 @@ class EditPhoneModal(ModalScreen[dict | None]):
         self.credential = credential
 
     def compose(self) -> ComposeResult:
-        """Create the Operator-grade modal layout."""
-        with Vertical(id="pwd-modal", classes="secure-terminal"):
+        """Create wide-format console panel layout."""
+        with Vertical(id="pwd-modal", classes="phone-modal-wide"):
             # HUD Header with status indicator
             with Vertical(classes="modal-header"):
                 with Horizontal(classes="modal-header-row"):
@@ -193,36 +200,55 @@ class EditPhoneModal(ModalScreen[dict | None]):
                     )
                     yield Static("STATUS: EDIT", classes="modal-status")
 
-            with Vertical(id="pwd-form"):
-                yield Label("> TARGET_DEVICE", classes="input-label")
-                yield Input(
-                    value=self.credential.label,
-                    placeholder="e.g. BANK_HOTLINE",
-                    id="label-input",
-                )
+            # Form Body - Grid Layout
+            with Vertical(id="pwd-form", classes="pwd-form-grid"):
+                # Row 1 (Identity): Device Label spans full width
+                with Vertical(classes="form-row form-row-full"):
+                    yield Label("> TARGET_DEVICE", classes="input-label")
+                    yield Input(
+                        value=self.credential.label,
+                        placeholder="e.g. BANK_HOTLINE",
+                        id="label-input",
+                    )
 
-                yield Label("> UPLINK_NUMBER", classes="input-label")
-                yield Input(
-                    value=self.credential.phone,
-                    placeholder="+1 555 000 0000",
-                    id="phone-input",
-                )
+                # Row 2 (Credentials): Phone + PIN side-by-side
+                with Horizontal(classes="form-row form-row-split"):
+                    with Vertical(classes="form-col"):
+                        yield Label("> UPLINK_NUMBER", classes="input-label")
+                        yield Input(
+                            value=self.credential.phone,
+                            placeholder="+1 555 000 0000",
+                            id="phone-input",
+                        )
+                    with Vertical(classes="form-col"):
+                        yield Label(
+                            "> ACCESS_PIN [BLANK = KEEP]", classes="input-label"
+                        )
+                        yield Input(
+                            placeholder="••••••",
+                            password=True,
+                            id="pin-input",
+                        )
 
-                yield Label("> ACCESS_PIN [BLANK = KEEP]", classes="input-label")
-                yield Input(placeholder="••••••", password=True, id="pin-input")
+                # Row 3 (Notes): Full width at bottom
+                with Vertical(classes="form-row form-row-full"):
+                    yield Label("> METADATA", classes="input-label")
+                    yield Input(
+                        value=self.credential.notes or "",
+                        placeholder="OPTIONAL_NOTES",
+                        id="notes-input",
+                    )
 
-                yield Label("> METADATA", classes="input-label")
-                yield Input(
-                    value=self.credential.notes or "",
-                    placeholder="OPTIONAL_NOTES",
-                    id="notes-input",
-                )
-
-            with Horizontal(id="modal-buttons"):
+            # Footer Actions - docked bottom, right aligned
+            with Horizontal(id="modal-buttons", classes="modal-footer"):
                 yield Button(r"\[ ABORT ]", id="cancel-button")
                 yield Button(
                     r"\[ ENCRYPT & COMMIT ]", variant="primary", id="save-button"
                 )
+
+    def on_mount(self) -> None:
+        """Focus first input (Device Label field)."""
+        self.query_one("#label-input", Input).focus()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle button press."""
@@ -304,7 +330,7 @@ class ConfirmDeleteModal(ModalScreen[bool]):
 
 
 class ViewPhoneModal(ModalScreen[None]):
-    """Modal for viewing a phone credential - Operator Grade Secure Read Console."""
+    """Modal for viewing a phone credential - Wide Console Panel Layout."""
 
     BINDINGS = [
         Binding("escape", "close", "Close"),
@@ -316,7 +342,7 @@ class ViewPhoneModal(ModalScreen[None]):
         self.credential = credential
 
     def compose(self) -> ComposeResult:
-        """Create the Operator-grade view modal layout."""
+        """Create wide-format console panel view layout."""
         # Get PIN strength for visual indicator
         strength = check_strength(self.credential.password)
         strength_color = _get_strength_color(strength.score)
@@ -325,54 +351,62 @@ class ViewPhoneModal(ModalScreen[None]):
             f"[{strength_color}]{'█' * filled}[/][#1e293b]{'░' * (5 - filled)}[/]"
         )
 
-        with Vertical(id="pwd-modal", classes="secure-terminal"):
+        with Vertical(id="pwd-modal", classes="phone-modal-wide"):
             # HUD Header with status indicator
             with Vertical(classes="modal-header"):
                 with Horizontal(classes="modal-header-row"):
                     yield Static("[ :: SECURE READ PROTOCOL :: ]", id="modal-title")
                     yield Static("STATUS: DECRYPTED", classes="modal-status")
 
-            # Data Display Body
-            with Vertical(id="pwd-form"):
-                # Row 1: Label (Device)
-                yield Label("> DEVICE_NAME", classes="input-label")
-                yield Static(
-                    f"  {self.credential.label}", classes="view-value", id="label-value"
-                )
-
-                # Row 2: Phone Number
-                yield Label("> UPLINK_NUMBER", classes="input-label")
-                yield Static(
-                    f"  {self.credential.phone}", classes="view-value", id="phone-value"
-                )
-
-                # Row 3: PIN (Secret)
-                yield Label("> ACCESS_PIN", classes="input-label")
-                yield Static(
-                    f"  [#d946ef]{self.credential.password}[/]",
-                    classes="view-value secret",
-                    id="pin-value",
-                )
-
-                # Row 4: Security Level
-                yield Label("> COMPLEXITY", classes="input-label")
-                yield Static(
-                    f"  {security_bars} [{strength_color}]{strength.label.upper()}[/]",
-                    classes="view-value",
-                    id="strength-value",
-                )
-
-                # Row 5: Notes (if present)
-                if self.credential.notes:
-                    yield Label("> METADATA", classes="input-label")
+            # Data Display Body - Grid Layout
+            with Vertical(id="pwd-form", classes="pwd-form-grid"):
+                # Row 1 (Identity): Device Label spans full width
+                with Vertical(classes="form-row form-row-full"):
+                    yield Label("> TARGET_DEVICE", classes="input-label")
                     yield Static(
-                        f"  {self.credential.notes}",
+                        f"  {self.credential.label}",
                         classes="view-value",
-                        id="notes-value",
+                        id="label-value",
                     )
 
-            # Footer Actions - right aligned
-            with Horizontal(id="modal-buttons"):
+                # Row 2 (Credentials): Phone + PIN side-by-side
+                with Horizontal(classes="form-row form-row-split"):
+                    with Vertical(classes="form-col"):
+                        yield Label("> UPLINK_NUMBER", classes="input-label")
+                        yield Static(
+                            f"  {self.credential.phone}",
+                            classes="view-value",
+                            id="phone-value",
+                        )
+                    with Vertical(classes="form-col"):
+                        yield Label("> ACCESS_PIN", classes="input-label")
+                        yield Static(
+                            f"  [#22c55e]{self.credential.password}[/]",
+                            classes="view-value secret",
+                            id="pin-value",
+                        )
+
+                # Row 3 (Security): Strength indicator spans full width
+                with Vertical(classes="form-row form-row-full"):
+                    yield Label("> SECURITY_LEVEL", classes="input-label")
+                    yield Static(
+                        f"  {security_bars} [{strength_color}]{strength.label.upper()}[/]",
+                        classes="view-value",
+                        id="strength-value",
+                    )
+
+                # Row 4 (Notes): Full width at bottom (if present)
+                if self.credential.notes:
+                    with Vertical(classes="form-row form-row-full"):
+                        yield Label("> METADATA", classes="input-label")
+                        yield Static(
+                            f"  {self.credential.notes}",
+                            classes="view-value",
+                            id="notes-value",
+                        )
+
+            # Footer Actions - docked bottom, right aligned
+            with Horizontal(id="modal-buttons", classes="modal-footer"):
                 yield Button(r"\[ DISMISS ]", variant="default", id="cancel-button")
                 yield Button(r"\[ COPY PIN ]", variant="primary", id="save-button")
 

--- a/passfx/styles/passfx.tcss
+++ b/passfx/styles/passfx.tcss
@@ -2558,7 +2558,7 @@ NotesScreen #notes-table > .datatable--odd-row {
 }
 
 /* ═══════════════════════════════════════════════════════════════════════════
-   PASSWORD MODALS - WIDE CONSOLE PANEL LAYOUT
+   PASSWORD MODALS - WIDE CONSOLE PANEL LAYOUT (PURPLE ACCENT)
    Wide-format horizontal layout for improved data density
    ═══════════════════════════════════════════════════════════════════════════ */
 
@@ -2570,7 +2570,7 @@ NotesScreen #notes-table > .datatable--odd-row {
     height: auto;
     max-height: 80%;
     background: $operator-black;
-    border: heavy $operator-primary;
+    border: heavy $operator-secondary;
     padding: 0;
 }
 
@@ -2723,7 +2723,7 @@ NotesScreen #notes-table > .datatable--odd-row {
     height: auto;
     background: $operator-black;
     padding: 1 2;
-    border-bottom: heavy $operator-primary;
+    border-bottom: heavy $operator-secondary;
 }
 
 .password-modal-wide .modal-header-row {
@@ -2734,7 +2734,7 @@ NotesScreen #notes-table > .datatable--odd-row {
 
 .password-modal-wide #modal-title {
     text-style: bold;
-    color: $operator-primary;
+    color: $operator-secondary;
     text-align: left;
     padding: 0;
     margin: 0;
@@ -2743,6 +2743,198 @@ NotesScreen #notes-table > .datatable--odd-row {
 }
 
 .password-modal-wide .modal-status {
+    width: auto;
+    height: 1;
+    color: $pfx-success;
+    text-style: bold;
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   PHONE MODAL WIDE - WIDE CONSOLE PANEL LAYOUT (PINK ACCENT)
+   Mirrors password-modal-wide but with pink accent for phones
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* Wide modal container - 90% width, max 120 for ultra-wide screens */
+#pwd-modal.phone-modal-wide {
+    width: 90%;
+    max-width: 120;
+    min-width: 80;
+    height: auto;
+    max-height: 80%;
+    background: $operator-black;
+    border: heavy #ec4899;
+    padding: 0;
+}
+
+/* Grid-based form container */
+.phone-modal-wide .pwd-form-grid {
+    padding: 1 3;
+    background: $operator-black;
+    width: 100%;
+}
+
+/* Form row - base styles */
+.phone-modal-wide .form-row {
+    width: 100%;
+    height: auto;
+    margin-bottom: 1;
+}
+
+/* Full width row (Label, Notes) */
+.phone-modal-wide .form-row-full {
+    width: 100%;
+}
+
+/* Split row - side-by-side fields (Phone + PIN) */
+.phone-modal-wide .form-row-split {
+    width: 100%;
+    height: auto;
+    align: left top;
+}
+
+/* Column for side-by-side inputs (50% each) */
+.phone-modal-wide .form-col {
+    width: 1fr;
+    height: auto;
+    padding-right: 2;
+}
+
+.phone-modal-wide .form-col:last-child {
+    padding-right: 0;
+}
+
+/* Input labels - terminal style with prompt */
+.phone-modal-wide .input-label {
+    color: #ec4899;
+    text-style: bold;
+    padding: 1 0 0 0;
+    margin: 0;
+    height: 1;
+}
+
+/* Terminal-style inputs - left border accent */
+.phone-modal-wide Input {
+    background: $operator-surface;
+    border: none;
+    border-left: solid $operator-muted;
+    padding: 1 1 0 2;
+    margin: 0 0 0 0;
+    color: $pfx-fg;
+    width: 100%;
+    height: 3;
+}
+
+/* Focus state - pink accent with highlighted left border */
+.phone-modal-wide Input:focus {
+    border-left: heavy #ec4899;
+    background: #0a0a12;
+}
+
+/* PIN input styling - green accent for secret fields */
+.phone-modal-wide #pin-input {
+    border-left: solid $pfx-success 50%;
+}
+
+.phone-modal-wide #pin-input:focus {
+    border-left: heavy $pfx-success;
+    background: #0a120a;
+}
+
+/* View value display - terminal output style */
+.phone-modal-wide .view-value {
+    background: $operator-surface;
+    border: none;
+    border-left: solid $operator-muted;
+    padding: 0 1 0 2;
+    margin: 0;
+    color: $pfx-fg;
+    width: 100%;
+    height: 3;
+    content-align: left middle;
+}
+
+.phone-modal-wide .view-value.secret {
+    border-left: solid $pfx-success 50%;
+    color: $pfx-success;
+}
+
+/* Modal footer - docked to bottom, right-aligned buttons */
+.phone-modal-wide .modal-footer {
+    padding: 1 3 2 3;
+    align: right middle;
+    background: $operator-black;
+    border-top: solid $operator-muted 30%;
+    width: 100%;
+    height: auto;
+    dock: bottom;
+}
+
+/* Cancel button styling */
+.phone-modal-wide #cancel-button {
+    background: transparent;
+    color: #64748b;
+    border: solid #475569;
+    min-width: 14;
+}
+
+.phone-modal-wide #cancel-button:hover {
+    background: #1e293b;
+    color: #94a3b8;
+    border: solid #1e293b;
+}
+
+.phone-modal-wide #cancel-button:focus {
+    background: #1e293b;
+    color: #e2e8f0;
+    border: solid #1e293b;
+}
+
+/* Save button styling - green accent */
+.phone-modal-wide #save-button {
+    background: transparent;
+    color: $pfx-success;
+    border: solid $pfx-success;
+    text-style: bold;
+    min-width: 24;
+}
+
+.phone-modal-wide #save-button:hover {
+    background: $pfx-success;
+    color: $operator-black;
+}
+
+.phone-modal-wide #save-button:focus {
+    background: $pfx-success;
+    color: $operator-black;
+    text-style: bold;
+}
+
+/* HUD Header for wide modals */
+.phone-modal-wide .modal-header {
+    width: 100%;
+    height: auto;
+    background: $operator-black;
+    padding: 1 2;
+    border-bottom: heavy #ec4899;
+}
+
+.phone-modal-wide .modal-header-row {
+    width: 100%;
+    height: 1;
+    align: left middle;
+}
+
+.phone-modal-wide #modal-title {
+    text-style: bold;
+    color: #ec4899;
+    text-align: left;
+    padding: 0;
+    margin: 0;
+    width: 1fr;
+    border: none;
+}
+
+.phone-modal-wide .modal-status {
     width: auto;
     height: 1;
     color: $pfx-success;


### PR DESCRIPTION
## Summary

- Apply wide-format console panel layout to Phone modals (Add, View, Edit)
- Add screen-specific color accents: purple for Passwords, pink for Phones
- Maintain visual consistency with Password modal redesign from #117

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure / CI / tooling
- [x] Refactoring (no functional changes)

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] N/A (documentation only)

**Test Details:**
- All 1431 existing tests pass
- Code quality checks (ruff, mypy, bandit) pass
- Pre-commit hooks pass

## Risk Assessment

**Risk level:** Low

**Areas affected:**
- `passfx/screens/phones.py` - Add/Edit/View modal compose methods
- `passfx/styles/passfx.tcss` - New `.phone-modal-wide` CSS classes, updated `.password-modal-wide` accent color

No changes to business logic, data flow, or security-sensitive code.

## Security Considerations

- [x] N/A (no security-sensitive changes)

This is a pure UI/styling refactor with no changes to credential handling, encryption, or storage.

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format