### PR TITLE
feat(cli): add --help and --version CLI flags

### DIFF
--- a/passfx/cli.py
+++ b/passfx/cli.py
@@ -1,10 +1,12 @@
 """Main CLI entry point for PassFX.
 
 Entry point with signal handling for graceful shutdown and cleanup.
+Handles CLI arguments (--help, --version) before launching the TUI.
 """
 
 from __future__ import annotations
 
+import argparse
 import signal
 import sys
 from types import FrameType
@@ -14,11 +16,77 @@ import setproctitle
 from passfx.app import PassFXApp
 from passfx.utils.clipboard import emergency_cleanup
 
+# Version constant - kept in sync with pyproject.toml
+__version__ = "1.0.2"
+
+# Help text for --help output
+HELP_TEXT = """\
+passfx - A secure terminal password manager
+
+USAGE:
+    passfx                   Launch the password manager
+    passfx --help            Show this help message
+    passfx --version         Show version information
+
+FIRST RUN:
+    Create a master password (12+ chars, mixed case, digit, symbol).
+    WARNING: There is no password recovery. Forget it, lose everything.
+
+DATA LOCATION:
+    ~/.passfx/vault.enc      Encrypted credentials
+    ~/.passfx/salt           Cryptographic salt
+
+SECURITY:
+    - Fernet encryption (AES-128-CBC + HMAC-SHA256)
+    - PBKDF2 key derivation (480,000 iterations)
+    - No network, no cloud, no sync
+    - Clipboard auto-clears after 15 seconds
+
+NAVIGATION:
+    q             Quit
+    Esc           Go back
+    a / e / d     Add / Edit / Delete
+    c             Copy to clipboard
+    Ctrl+K        Global search
+
+More info: https://github.com/dinesh-git17/passfx
+"""
+
 # Terminal title - shown in terminal tab/window
 TERMINAL_TITLE = "◀ PASSFX ▶ Your passwords. Offline. Encrypted."
 
 # Global app reference for signal handlers
 _app: PassFXApp | None = None  # pylint: disable=invalid-name
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Handles --help and --version flags before TUI launch.
+    Uses custom help text for better user experience.
+    """
+    parser = argparse.ArgumentParser(
+        prog="passfx",
+        description="A secure terminal password manager",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        add_help=False,  # We handle --help ourselves for custom output
+    )
+
+    parser.add_argument(
+        "-h",
+        "--help",
+        action="store_true",
+        help="Show this help message and exit",
+    )
+
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="store_true",
+        help="Show version information and exit",
+    )
+
+    return parser.parse_args()
 
 
 def set_terminal_title(title: str) -> None:
@@ -57,11 +125,27 @@ def _setup_signal_handlers() -> None:
 def main() -> int:
     """Main entry point for PassFX.
 
+    Parses CLI arguments first, then launches TUI if no special flags.
+
     Returns:
         Exit code (0 for success).
     """
     global _app  # pylint: disable=global-statement
 
+    # Parse CLI arguments before anything else
+    args = _parse_args()
+
+    # Handle --help flag
+    if args.help:
+        print(HELP_TEXT)
+        return 0
+
+    # Handle --version flag
+    if args.version:
+        print(f"passfx {__version__}")
+        return 0
+
+    # No special flags - launch the TUI
     # Set process title (removes "Python" from terminal tab)
     setproctitle.setproctitle("PassFX")
     set_terminal_title(TERMINAL_TITLE)


### PR DESCRIPTION
## Summary

Add standard Unix CLI flags `--help` / `-h` and `--version` / `-V` to PassFX. These flags are handled before the TUI launches, providing immediate feedback without starting the application.

## Motivation

Users expect standard CLI behavior from command-line tools. Running `passfx --help` previously just launched the TUI, ignoring the flag entirely. This change makes PassFX behave like a well-designed Unix tool.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure / CI / tooling
- [ ] Refactoring (no functional changes)

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed
- [ ] N/A (documentation only)

**Test coverage:**
- 10 new tests for CLI argument parsing
- Existing tests updated with `mock_sys_argv` fixture to prevent argparse from parsing pytest arguments
- All 1452 tests pass

## Risk Assessment

**Risk level:** Low

**Areas affected:**
- `passfx/cli.py` - CLI entry point (argparse added before TUI launch)
- No changes to core security logic, vault operations, or TUI behavior

## Security Considerations

- [x] No credentials or secrets exposed
- [x] Sensitive data properly cleared from memory
- [x] File permissions verified (0600/0700)
- [x] N/A (no security-sensitive changes)

The help text includes security reminders (no password recovery, encryption details, data location) but does not expose any sensitive data.

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format