### PR TITLE
chore(pypi): improve project URLs for SEO discoverability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,11 @@ dev = [
 passfx = "passfx.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/dinesh-git17/passfx"
-Documentation = "https://github.com/dinesh-git17/passfx#readme"
+Homepage = "https://passfx.dineshd.dev"
+Documentation = "https://github.com/dinesh-git17/passfx/tree/main/docs"
+Repository = "https://github.com/dinesh-git17/passfx"
 Issues = "https://github.com/dinesh-git17/passfx/issues"
+Changelog = "https://github.com/dinesh-git17/passfx/blob/main/docs/CHANGELOG.md"
 
 [tool.hatch.build.targets.wheel]
 packages = ["passfx"]


### PR DESCRIPTION
## Summary

Improves PyPI project metadata URLs to enhance SEO discoverability and provide proper backlinks between the landing page, GitHub repository, and documentation.

## Motivation

SEO audit identified gaps in PyPI metadata:
- Homepage pointed to GitHub instead of the landing page
- No explicit "Repository" field (expected by some crawlers)
- Documentation linked to README anchor instead of docs directory
- Missing Changelog URL

These changes ensure PyPI (a high-authority domain) provides proper backlink equity to the landing page.

## Type of Change

- [x] Infrastructure / CI / tooling

## Testing

- [x] N/A (documentation only)

Verified pyproject.toml syntax with `check toml` pre-commit hook.

## Risk Assessment

**Risk level:** Low

**Areas affected:** PyPI project page metadata only. No runtime code changes.

## Security Considerations

- [x] N/A (no security-sensitive changes)

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format