### PR TITLE
fix(tests): use fixed ID in credit card repr test to prevent flakiness

### DIFF
--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -550,6 +550,7 @@ class TestCreditCard:
     def test_repr_redacts_card_number_and_cvv(self) -> None:
         """String representation hides card_number and cvv."""
         card = CreditCard(
+            id="aabbccdd",  # Fixed ID to avoid random collision with CVV
             label="Chase",
             card_number="4111222233334444",
             expiry="12/25",


### PR DESCRIPTION
## Summary

Fixes a flaky test that intermittently fails when the randomly generated credit card ID happens to contain the CVV value.

## Motivation

The test `test_repr_redacts_card_number_and_cvv` was failing in CI with:

```
assert '789' not in "CreditCard(id='88789bc2', ...)"
```

The ID `88789bc2` contained `789`, which matched the CVV being tested.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Unit tests added/updated
- [x] Manual testing performed

```bash
pytest tests/unit/core/test_models.py::TestCreditCard::test_repr_redacts_card_number_and_cvv -v
# PASSED
```

## Risk Assessment

**Risk level:** Low

**Areas affected:** Test file only. No production code changes.

## Security Considerations

- [x] N/A (no security-sensitive changes)

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format