### PR TITLE
fix(ci): remove invalid pull_request context from concurrency group

### DIFF
--- a/.github/workflows/install-tests.yml
+++ b/.github/workflows/install-tests.yml
@@ -33,9 +33,9 @@ on:
         default: true
         type: boolean
 
-# Cancel in-progress runs for the same PR/branch
+# Cancel in-progress runs (only one install test suite at a time)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary

Fix linter warning about invalid context access in install-tests.yml concurrency group.

## Problem

The concurrency group was using `github.event.pull_request.number`:

```yaml
group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
```

But this workflow only triggers on:
- `workflow_run` (after PyPI publish)
- `workflow_dispatch` (manual trigger)

Neither event type has a `pull_request` context, so `github.event.pull_request.number` is always undefined.

## Solution

Use `github.ref` directly since it's valid for both trigger types:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Infrastructure / CI / tooling
- [ ] Refactoring (no functional changes)

## Testing

- [x] Linter warning resolved
- [x] YAML syntax valid

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code for obvious issues
- [x] Commit messages follow conventional format