### PR TITLE
chore(release): bump version to 1.0.3

### DIFF
--- a/homebrew/passfx.rb
+++ b/homebrew/passfx.rb
@@ -107,7 +107,7 @@ class Passfx < Formula
 
   test do
     # Verify CLI responds correctly
-    assert_match "passfx 1.0.2", shell_output("#{bin}/passfx --version")
+    assert_match "passfx 1.0.3", shell_output("#{bin}/passfx --version")
 
     # Verify help output contains expected content
     help_output = shell_output("#{bin}/passfx --help")

--- a/passfx/cli.py
+++ b/passfx/cli.py
@@ -17,7 +17,7 @@ from passfx.app import PassFXApp
 from passfx.utils.clipboard import emergency_cleanup
 
 # Version constant - kept in sync with pyproject.toml
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 # Help text for --help output
 HELP_TEXT = """\

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "passfx"
-version = "1.0.2"
+version = "1.0.3"
 description = "A secure, stylish terminal password manager. Your secrets are safe with us. Probably."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/install/validate_install.sh
+++ b/tests/install/validate_install.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 
 # Configuration
 INSTALL_METHOD="${1:-unknown}"
-EXPECTED_VERSION="1.0.2"
+EXPECTED_VERSION="1.0.3"
 EXIT_CODE=0
 TESTS_RUN=0
 TESTS_PASSED=0


### PR DESCRIPTION
## Summary

Version bump to 1.0.3 for release.

## Motivation

Release containing the Windows ACL fix (PR #143).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Infrastructure / CI / tooling
- [ ] Refactoring (no functional changes)

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [x] N/A (documentation only)

## Risk Assessment

**Risk level:** Low

**Areas affected:**
- Version strings only

## Security Considerations

- [ ] No credentials or secrets exposed
- [ ] Sensitive data properly cleared from memory
- [ ] File permissions verified (0600/0700)
- [x] N/A (no security-sensitive changes)

## Checklist

- [x] Code follows project style guidelines
- [x] `ruff check passfx/` passes
- [x] `mypy passfx/` passes
- [x] `bandit -r passfx/` passes (for security-sensitive changes)
- [x] Tests pass locally
- [x] Self-reviewed code for obvious issues
- [x] No print statements or debug code
- [x] Commit messages follow conventional format

## Release Notes for v1.0.3

### Bug Fixes
- **Windows**: Fixed `PlatformSecurityError: AddAccessAllowedAceEx failed: 1337` when creating vault on Windows. The ctypes SID buffer was being garbage collected prematurely, causing an invalid SID error.